### PR TITLE
Add support for saving binary data in data vault

### DIFF
--- a/data_vault.py
+++ b/data_vault.py
@@ -41,44 +41,16 @@ timeout = 5
 
 from __future__ import with_statement
 
-from labrad import types as T, util
-from labrad.server import LabradServer, Signal, setting
+import os
+import sys
 
-from twisted.internet.reactor import callLater
 from twisted.internet.defer import inlineCallbacks
 
-from ConfigParser import SafeConfigParser
+from labrad.server import LabradServer, Signal, setting
+import labrad.util
 
-# ConfigParser is retarded and doesn't let you choose your newline separator,
-# so we overload it to make data vault files consistent across OSes.
-# In particular, Windows expects \r\n whereas Linux uses \n
-class DVSafeConfigParser(SafeConfigParser):
-    def write(self, fp, newline='\r\n'):
-        """Write an .ini-format representation of the configuration state."""
-        if self._defaults:
-            fp.write("[%s]" % DEFAULTSECT + newline)
-            for (key, value) in self._defaults.items():
-                fp.write(("%s = %s" + newline) % (key, str(value).replace('\n', '\n\t')))
-            fp.write(newline)
-        for section in self._sections:
-            fp.write("[%s]" % section + newline)
-            for (key, value) in self._sections[section].items():
-                if key != "__name__":
-                    fp.write(("%s = %s" + newline) %
-                             (key, str(value).replace('\n', '\n\t')))
-            fp.write(newline)
-
-import os, re
-from datetime import datetime
-
-try:
-    import numpy
-    print "Numpy imported."
-    useNumpy = True
-except ImportError, e:
-    print e
-    print "Numpy not imported.  The DataVault will operate, but will be slower."
-    useNumpy = False
+import datavault as dv
+from datavault import errors
 
 
 # TODO: tagging
@@ -89,758 +61,15 @@ except ImportError, e:
 #       tag information in the session
 
 
-# location of repository will get loaded from the registry
-DATADIR = None
-
-PRECISION = 12 # digits of precision to use when saving data
-DATA_FORMAT = '%%.%dG' % PRECISION
-FILE_TIMEOUT = 60 # how long to keep datafiles open if not accessed
-DATA_TIMEOUT = 300 # how long to keep data in memory if not accessed
-TIME_FORMAT = '%Y-%m-%d, %H:%M:%S'
-READ_SIZE_LIMIT_BYTES = 100000
-
-## error messages
-
-class NoDatasetError(T.Error):
-    """Please open a dataset first."""
-    code = 2
-
-class DatasetNotFoundError(T.Error):
-    code = 3
-    def __init__(self, name):
-        self.msg="Dataset '%s' not found!" % name
-
-class DirectoryExistsError(T.Error):
-    code = 4
-    def __init__(self, name):
-        self.msg = "Directory '%s' already exists!" % name
-
-class DirectoryNotFoundError(T.Error):
-    code = 5
-
-class EmptyNameError(T.Error):
-    """Names of directories or keys cannot be empty"""
-    code = 6
-    def __init__(self, path):
-        self.msg = "Directory %s does not exist!" % (path,)
-        
-class ReadOnlyError(T.Error):
-    """Points can only be added to datasets created with 'new'."""
-    code = 7
-
-class BadDataError(T.Error):
-    code = 8
-    def __init__(self, varcount, gotcount):
-        self.msg = 'Dataset requires %d values per datapoint not %d.' % (varcount, gotcount)
-
-class BadParameterError(T.Error):
-    code = 9
-    def __init__(self, name):
-        self.msg = "Parameter '%s' not found." % name
-
-class ParameterInUseError(T.Error):
-    code = 10
-    def __init__(self, name):
-        self.msg = "Already a parameter called '%s'." % name
-
-
-## filename translation
-        
-encodings = [
-    ('%','%p'),
-    ('/','%f'),
-    ('\\','%b'),
-    (':','%c'),
-    ('*','%a'),
-    ('?','%q'),
-    ('"','%r'),
-    ('<','%l'),
-    ('>','%g'),
-    ('|','%v')
-]
-
-def dsEncode(name):
-    for char, code in encodings:
-        name = name.replace(char, code)
-    return name
-
-def dsDecode(name):
-    for char, code in encodings[1:] + encodings[0:1]:
-        name = name.replace(code, char)
-    return name
-
-def filedir(path):
-    return os.path.join(DATADIR, *[dsEncode(d) + '.dir' for d in path[1:]])
-    
-    
-## time formatting
-    
-def timeToStr(t):
-    return t.strftime(TIME_FORMAT)
-
-def timeFromStr(s):
-    return datetime.strptime(s, TIME_FORMAT)
-
-
-## variable parsing
-    
-re_label = re.compile(r'^([^\[(]*)') # matches up to the first [ or (
-re_legend = re.compile(r'\((.*)\)') # matches anything inside ( )
-re_units = re.compile(r'\[(.*)\]') # matches anything inside [ ]
-
-def getMatch(pat, s, default=None):
-    matches = re.findall(pat, s)
-    if len(matches) == 0:
-        if default is None:
-            raise Exception("Cannot parse '%s'." % s)
-        return default
-    return matches[0].strip()
-
-def parseIndependent(s):
-    label = getMatch(re_label, s)
-    units = getMatch(re_units, s, '')
-    return label, units
-    
-def parseDependent(s):
-    label = getMatch(re_label, s)
-    legend = getMatch(re_legend, s, '')
-    units = getMatch(re_units, s, '')
-    return label, legend, units
-    
-
-
-class Session(object):
-    """Stores information about a directory on disk.
-    
-    One session object is created for each data directory accessed.
-    The session object manages reading from and writing to the config
-    file, and manages the datasets in this directory.
-    """
-    
-    # keep a dictionary of all created session objects
-    _sessions = {}
-
-    @classmethod
-    def getAll(cls):
-        return cls._sessions.values()
-    
-    @staticmethod
-    def exists(path):
-        """Check whether a session exists on disk for a given path.
-        
-        This does not tell us whether a session object has been
-        created for that path.
-        """
-        return os.path.exists(filedir(path))
-    
-    def __new__(cls, path, parent):
-        """Get a Session object.
-        
-        If a session already exists for the given path, return it.
-        Otherwise, create a new session instance.
-        """
-        path = tuple(path)
-        if path in cls._sessions:
-            return cls._sessions[path]
-        inst = super(Session, cls).__new__(cls)
-        inst._init(path, parent)
-        cls._sessions[path] = inst
-        return inst
-
-    def _init(self, path, parent):
-        """Initialization that happens once when session object is created."""
-        self.path = path
-        self.parent = parent
-        self.dir = filedir(path)
-        self.infofile = os.path.join(self.dir, 'session.ini')
-        self.datasets = {}
-
-        if not os.path.exists(self.dir):
-            os.makedirs(self.dir)
-            
-            # notify listeners about this new directory
-            parent_session = Session(path[:-1], parent)
-            parent.onNewDir(path[-1], parent_session.listeners)
-           
-        if os.path.exists(self.infofile):
-            self.load()
-        else:
-            self.counter = 1
-            self.created = self.modified = datetime.now()
-            self.session_tags = {}
-            self.dataset_tags = {}
-
-        self.access() # update current access time and save
-        self.listeners = set()
-            
-    def load(self):
-        """Load info from the session.ini file."""
-        S = DVSafeConfigParser()
-        S.read(self.infofile)
-
-        sec = 'File System'
-        self.counter = S.getint(sec, 'Counter')
-
-        sec = 'Information'
-        self.created = timeFromStr(S.get(sec, 'Created'))
-        self.accessed = timeFromStr(S.get(sec, 'Accessed'))
-        self.modified = timeFromStr(S.get(sec, 'Modified'))
-
-        # get tags if they're there
-        if S.has_section('Tags'):
-            self.session_tags = eval(S.get('Tags', 'sessions', raw=True))
-            self.dataset_tags = eval(S.get('Tags', 'datasets', raw=True))
-        else:
-            self.session_tags = {}
-            self.dataset_tags = {}
-
-    def save(self):
-        """Save info to the session.ini file."""
-        S = DVSafeConfigParser()
-
-        sec = 'File System'
-        S.add_section(sec)
-        S.set(sec, 'Counter', repr(self.counter))
-
-        sec = 'Information'
-        S.add_section(sec)
-        S.set(sec, 'Created',  timeToStr(self.created))
-        S.set(sec, 'Accessed', timeToStr(self.accessed))
-        S.set(sec, 'Modified', timeToStr(self.modified))
-
-        sec = 'Tags'
-        S.add_section(sec)
-        S.set(sec, 'sessions', repr(self.session_tags))
-        S.set(sec, 'datasets', repr(self.dataset_tags))
-
-        with open(self.infofile, 'w') as f:
-            S.write(f)
-
-    def access(self):
-        """Update last access time and save."""
-        self.accessed = datetime.now()
-        self.save()
-
-    def listContents(self, tagFilters):
-        """Get a list of directory names in this directory."""
-        files = os.listdir(self.dir)
-        files.sort()
-        dirs = [dsDecode(s[:-4]) for s in files if s.endswith('.dir')]
-        datasets = [dsDecode(s[:-4]) for s in files if s.endswith('.csv')]
-        # apply tag filters
-        def include(entries, tag, tags):
-            """Include only entries that have the specified tag."""
-            return [e for e in entries
-                    if e in tags and tag in tags[e]]
-        def exclude(entries, tag, tags):
-            """Exclude all entries that have the specified tag."""
-            return [e for e in entries
-                    if e not in tags or tag not in tags[e]]
-        for tag in tagFilters:
-            if tag[:1] == '-':
-                filter = exclude
-                tag = tag[1:]
-            else:
-                filter = include
-            #print filter.__name__ + ':', tag
-            #print 'before:', dirs, datasets
-            dirs = filter(dirs, tag, self.session_tags)
-            datasets = filter(datasets, tag, self.dataset_tags)
-            #print 'after:', dirs, datasets
-        return dirs, datasets
-            
-    def listDatasets(self):
-        """Get a list of dataset names in this directory."""
-        files = os.listdir(self.dir)
-        files.sort()
-        return [dsDecode(s[:-4]) for s in files if s.endswith('.csv')]
-    
-    def newDataset(self, title, independents, dependents):
-        num = self.counter
-        self.counter += 1
-        self.modified = datetime.now()
-
-        name = '%05d - %s' % (num, title)
-        dataset = Dataset(self, name, title, create=True)
-        for i in independents:
-            dataset.addIndependent(i)
-        for d in dependents:
-            dataset.addDependent(d)
-        self.datasets[name] = dataset
-        self.access()
-        
-        # notify listeners about the new dataset
-        self.parent.onNewDataset(name, self.listeners)
-        return dataset
-        
-    def openDataset(self, name):
-        # first lookup by number if necessary
-        if isinstance(name, (int, long)):
-            for oldName in self.listDatasets():
-                num = int(oldName[:5])
-                if name == num:
-                    name = oldName
-                    break
-        # if it's still a number, we didn't find the set
-        if isinstance(name, (int, long)):
-            raise DatasetNotFoundError(name)
-
-        filename = dsEncode(name)
-        if not os.path.exists(os.path.join(self.dir, filename + '.csv')):
-            raise DatasetNotFoundError(name)
-
-        if name in self.datasets:
-            dataset = self.datasets[name]
-            dataset.access()
-        else:
-            # need to create a new wrapper for this dataset
-            dataset = Dataset(self, name)
-            self.datasets[name] = dataset
-        self.access()
-        
-        return dataset
-
-    def updateTags(self, tags, sessions, datasets):
-        def updateTagDict(tags, entries, d):
-            updates = []
-            for entry in entries:
-                changed = False
-                if entry not in d:
-                    d[entry] = set()
-                entryTags = d[entry]
-                for tag in tags:
-                    if tag[:1] == '-':
-                        # remove this tag
-                        tag = tag[1:]
-                        if tag in entryTags:
-                            entryTags.remove(tag)
-                            changed = True
-                    elif tag[:1] == '^':
-                        # toggle this tag
-                        tag = tag[1:]
-                        if tag in entryTags:
-                            entryTags.remove(tag)
-                        else:
-                            entryTags.add(tag)
-                        changed = True
-                    else:
-                        # add this tag
-                        if tag not in entryTags:
-                            entryTags.add(tag)
-                            changed = True
-                if changed:
-                    updates.append((entry, sorted(entryTags)))
-            return updates
-
-        sessUpdates = updateTagDict(tags, sessions, self.session_tags)
-        dataUpdates = updateTagDict(tags, datasets, self.dataset_tags)
-
-        self.access()
-        if len(sessUpdates) + len(dataUpdates):
-            # fire a message about the new tags
-            msg = (sessUpdates, dataUpdates)
-            self.parent.onTagsUpdated(msg, self.listeners)
-
-    def getTags(self, sessions, datasets):
-        sessTags = [(s, sorted(self.session_tags.get(s, []))) for s in sessions]
-        dataTags = [(d, sorted(self.dataset_tags.get(d, []))) for d in datasets]
-        return sessTags, dataTags
-
-class Dataset:
-    def __init__(self, session, name, title=None, num=None, create=False):
-        self.parent = session.parent
-        self.name = name
-        file_base = os.path.join(session.dir, dsEncode(name))
-        self.datafile = file_base + '.csv'
-        self.infofile = file_base + '.ini'
-        self.file # create the datafile, but don't do anything with it
-        self.listeners = set() # contexts that want to hear about added data
-        self.param_listeners = set()
-        self.comment_listeners = set()
-        
-        if create:
-            self.title = title
-            self.created = self.accessed = self.modified = datetime.now()
-            self.independents = []
-            self.dependents = []
-            self.parameters = []
-            self.comments = []
-            self.save()
-        else:
-            self.load()
-            self.access()
-
-    def load(self):
-        S = DVSafeConfigParser()
-        S.read(self.infofile)
-
-        gen = 'General'
-        self.title = S.get(gen, 'Title', raw=True)
-        self.created = timeFromStr(S.get(gen, 'Created'))
-        self.accessed = timeFromStr(S.get(gen, 'Accessed'))
-        self.modified = timeFromStr(S.get(gen, 'Modified'))
-
-        def getInd(i):
-            sec = 'Independent %d' % (i+1)
-            label = S.get(sec, 'Label', raw=True)
-            units = S.get(sec, 'Units', raw=True)
-            return dict(label=label, units=units)
-        count = S.getint(gen, 'Independent')
-        self.independents = [getInd(i) for i in range(count)]
-
-        def getDep(i):
-            sec = 'Dependent %d' % (i+1)
-            label = S.get(sec, 'Label', raw=True)
-            units = S.get(sec, 'Units', raw=True)
-            categ = S.get(sec, 'Category', raw=True)
-            return dict(label=label, units=units, category=categ)
-        count = S.getint(gen, 'Dependent')
-        self.dependents = [getDep(i) for i in range(count)]
-
-        def getPar(i):
-            sec = 'Parameter %d' % (i+1)
-            label = S.get(sec, 'Label', raw=True)
-            # TODO: big security hole! eval can execute arbitrary code
-            data = T.evalLRData(S.get(sec, 'Data', raw=True))
-            return dict(label=label, data=data)
-        count = S.getint(gen, 'Parameters')
-        self.parameters = [getPar(i) for i in range(count)]
-
-        # get comments if they're there
-        if S.has_section('Comments'):
-            def getComment(i):
-                sec = 'Comments'
-                time, user, comment = eval(S.get(sec, 'c%d' % i, raw=True))
-                return timeFromStr(time), user, comment
-            count = S.getint(gen, 'Comments')
-            self.comments = [getComment(i) for i in range(count)]
-        else:
-            self.comments = []
-        
-    def save(self):
-        S = DVSafeConfigParser()
-        
-        sec = 'General'
-        S.add_section(sec)
-        S.set(sec, 'Created',  timeToStr(self.created))
-        S.set(sec, 'Accessed', timeToStr(self.accessed))
-        S.set(sec, 'Modified', timeToStr(self.modified))
-        S.set(sec, 'Title',       self.title)
-        S.set(sec, 'Independent', repr(len(self.independents)))
-        S.set(sec, 'Dependent',   repr(len(self.dependents)))
-        S.set(sec, 'Parameters',  repr(len(self.parameters)))
-        S.set(sec, 'Comments',    repr(len(self.comments)))
-
-        for i, ind in enumerate(self.independents):
-            sec = 'Independent %d' % (i+1)
-            S.add_section(sec)
-            S.set(sec, 'Label', ind['label'])
-            S.set(sec, 'Units', ind['units'])
-
-        for i, dep in enumerate(self.dependents):
-            sec = 'Dependent %d' % (i+1)
-            S.add_section(sec)
-            S.set(sec, 'Label',    dep['label'])
-            S.set(sec, 'Units',    dep['units'])
-            S.set(sec, 'Category', dep['category'])
-
-        for i, par in enumerate(self.parameters):
-            sec = 'Parameter %d' % (i+1)
-            S.add_section(sec)
-            S.set(sec, 'Label', par['label'])
-            # TODO: smarter saving here, since eval'ing is insecure
-            S.set(sec, 'Data', repr(par['data']))
-
-        sec = 'Comments'
-        S.add_section(sec)
-        for i, (time, user, comment) in enumerate(self.comments):
-            time = timeToStr(time)
-            S.set(sec, 'c%d' % i, repr((time, user, comment)))
-            
-        with open(self.infofile, 'w') as f:
-            S.write(f)
-
-    def access(self):
-        """Update time of last access for this dataset."""
-        self.accessed = datetime.now()
-        self.save()
-
-    @property
-    def file(self):
-        """Open the datafile on demand.
-
-        The file is also scheduled to be closed
-        if it has not accessed for a while.
-        """
-        if not hasattr(self, '_file'):
-            self._file = open(self.datafile, 'a+') # append data
-            self._fileTimeoutCall = callLater(FILE_TIMEOUT, self._fileTimeout)
-        else:
-            self._fileTimeoutCall.reset(FILE_TIMEOUT)
-        return self._file
-        
-    def _fileTimeout(self):
-        self._file.close()
-        del self._file
-        del self._fileTimeoutCall
-    
-    def _fileSize(self):
-        """Check the file size of our datafile."""
-        # does this include the size before the file has been flushed to disk?
-        return os.fstat(self.file.fileno()).st_size
-    
-    @property
-    def data(self):
-        """Read data from file on demand.
-        
-        The data is scheduled to be cleared from memory unless accessed."""
-        if not hasattr(self, '_data'):
-            self._data = []
-            self._datapos = 0
-            self._dataTimeoutCall = callLater(DATA_TIMEOUT, self._dataTimeout)
-        else:
-            self._dataTimeoutCall.reset(DATA_TIMEOUT)
-        f = self.file
-        f.seek(self._datapos)
-        lines = f.readlines()
-        self._data.extend([float(n) for n in line.split(',')] for line in lines)
-        self._datapos = f.tell()
-        return self._data
-    
-    def _dataTimeout(self):
-        del self._data
-        del self._datapos
-        del self._dataTimeoutCall
-    
-    def _saveData(self, data):
-        f = self.file
-        for row in data:
-            # always save with dos linebreaks
-            f.write(', '.join(DATA_FORMAT % v for v in row) + '\r\n')
-        f.flush()
-    
-    def addIndependent(self, label):
-        """Add an independent variable to this dataset."""
-        if isinstance(label, tuple):
-            label, units = label
-        else:
-            label, units = parseIndependent(label)
-        d = dict(label=label, units=units)
-        self.independents.append(d)
-        self.save()
-
-    def addDependent(self, label):
-        """Add a dependent variable to this dataset."""
-        if isinstance(label, tuple):
-            label, legend, units = label
-        else:
-            label, legend, units = parseDependent(label)
-        d = dict(category=label, label=legend, units=units)
-        self.dependents.append(d)
-        self.save()
-
-    def addParameter(self, name, data, saveNow=True):
-        self._addParam(name, data)
-        if saveNow:
-            self.save()
-        
-        # notify all listening contexts
-        self.parent.onNewParameter(None, self.param_listeners)
-        self.param_listeners = set()
-        return name
-
-    def addParameters(self, params, saveNow=True):
-        for name, data in params:
-            self._addParam(name, data)
-        if saveNow:
-            self.save()
-        
-        # notify all listening contexts
-        self.parent.onNewParameter(None, self.param_listeners)
-        self.param_listeners = set()
-        
-    def _addParam(self, name, data):
-        for p in self.parameters:
-            if p['label'] == name:
-                raise ParameterInUseError(name)
-        d = dict(label=name, data=data)
-        self.parameters.append(d)
-        
-    def getParameter(self, name, case_sensitive=True):
-        for p in self.parameters:
-            if case_sensitive:
-                if p['label'] == name:
-                    return p['data']
-            else:
-                if p['label'].lower() == name.lower():
-                    return p['data']
-        raise BadParameterError(name)
-        
-    def addData(self, data):
-        varcount = len(self.independents) + len(self.dependents)
-        if not len(data) or not isinstance(data[0], list):
-            data = [data]
-        if len(data[0]) != varcount:
-            raise BadDataError(varcount, len(data[0]))
-            
-        # append the data to the file
-        self._saveData(data)
-        
-        # notify all listening contexts
-        self.parent.onDataAvailable(None, self.listeners)
-        self.listeners = set()
-    
-    def getData(self, limit, start):
-        if limit is None and self._filesize() > READ_SIZE_LIMIT_BYTES:
-            raise Exception('Read in smaller chunks of data')
-        if limit is None:
-            data = self.data[start:]
-        else:
-            data = self.data[start:start+limit]
-        return data, start + len(data)
-        
-    def keepStreaming(self, context, pos):
-        if pos < len(self.data):
-            if context in self.listeners:
-                self.listeners.remove(context)
-            self.parent.onDataAvailable(None, context)
-        else:
-            self.listeners.add(context)
-            
-    def addComment(self, user, comment):
-        self.comments.append((datetime.now(), user, comment))
-        self.save()
-        
-        # notify all listening contexts
-        self.parent.onCommentsAvailable(None, self.comment_listeners)
-        self.comment_listeners = set()
-
-    def getComments(self, limit, start):
-        if limit is None:
-            comments = self.comments[start:]
-        else:
-            comments = self.comments[start:start+limit]
-        return comments, start + len(comments)
-        
-    def keepStreamingComments(self, context, pos):
-        if pos < len(self.comments):
-            if context in self.comment_listeners:
-                self.comment_listeners.remove(context)
-            self.parent.onCommentsAvailable(None, context)
-        else:
-            self.comment_listeners.add(context)
-        
-
-class NumpyDataset(Dataset):
-
-    def _get_data(self):
-        """Read data from file on demand.
-        
-        The data is scheduled to be cleared from memory unless accessed."""
-        if not hasattr(self, '_data'):
-            try:
-                # if the file is empty, this line can barf in certain versions
-                # of numpy.  Clearly, if the file does not exist on disk, this
-                # will be the case.  Even if the file exists on disk, we must
-                # check its size
-                if self._fileSize() > 0:
-                    self._data = numpy.loadtxt(self.file, delimiter=',')
-                else:
-                    self._data = numpy.array([[]])
-                if len(self._data.shape) == 1:
-                    self._data.shape = (1, len(self._data))
-            except ValueError:
-                # no data saved yet
-                # this error is raised by numpy <=1.2
-                self._data = numpy.array([[]])
-            except IOError:
-                # no data saved yet
-                # this error is raised by numpy 1.3
-                self.file.seek(0)
-                self._data = numpy.array([[]])
-            self._dataTimeoutCall = callLater(DATA_TIMEOUT, self._dataTimeout)
-        else:
-            self._dataTimeoutCall.reset(DATA_TIMEOUT)
-        return self._data
-
-    def _set_data(self, data):
-        self._data = data
-        
-    data = property(_get_data, _set_data)
-    
-    def _saveData(self, data):
-        f = self.file
-	# always save with dos linebreaks (requires numpy 1.5.0 or greater)
-        numpy.savetxt(f, data, fmt=DATA_FORMAT, delimiter=',', newline='\r\n')
-        f.flush()
-    
-    def _dataTimeout(self):
-        del self._data
-        del self._dataTimeoutCall
-        
-    def addData(self, data):
-        varcount = len(self.independents) + len(self.dependents)
-        data = data.asarray
-        
-        # reshape single row
-        if len(data.shape) == 1:
-            data.shape = (1, data.size)
-        
-        # check row length
-        if data.shape[-1] != varcount:
-            raise BadDataError(varcount, data.shape[-1])
-        
-        # append data to in-memory data
-        if self.data.size > 0:
-            self.data = numpy.vstack((self.data, data))
-        else:
-            self.data = data
-            
-        # append data to file
-        self._saveData(data)
-        
-        # notify all listening contexts
-        self.parent.onDataAvailable(None, self.listeners)
-        self.listeners = set()
-    
-    def getData(self, limit, start):
-        if limit is None:
-            data = self.data[start:]
-        else:
-            data = self.data[start:start+limit]
-        # nrows should be zero for an empty row
-        nrows = len(data) if data.size > 0 else 0
-        return data, start + nrows
-        
-    def keepStreaming(self, context, pos):
-        # cheesy hack: if pos == 0, we only need to check whether
-        # the filesize is nonzero
-        if pos == 0:
-            more = os.path.getsize(self.datafile) > 0
-        else:
-            nrows = len(self.data) if self.data.size > 0 else 0
-            more = pos < nrows
-        if more:
-            if context in self.listeners:
-                self.listeners.remove(context)
-            self.parent.onDataAvailable(None, context)
-        else:
-            self.listeners.add(context)
-        
-if useNumpy:
-    Dataset = NumpyDataset
-
-
 class DataVault(LabradServer):
     name = 'Data Vault'
-    
+
     @inlineCallbacks
     def initServer(self):
         # load configuration info from registry
-        global DATADIR
         try:
             path = ['', 'Servers', self.name, 'Repository']
-            nodename = util.getNodeName()
+            nodename = labrad.util.getNodeName()
             reg = self.client.registry
             try:
                 # try to load for this node
@@ -854,24 +83,23 @@ class DataVault(LabradServer):
                 p.cd(path)
                 p.get('__default__', 's')
                 ans = yield p.send()
-            DATADIR = ans.get
-            gotLocation = True
+            datadir = ans.get
         except:
             try:
                 print 'Could not load repository location from registry.'
                 print 'Please enter data storage directory or hit enter to use the current directory:'
-                DATADIR = raw_input('>>>')
-                if DATADIR == '':
-                    DATADIR = os.path.join(os.path.split(__file__)[0], '__data__')
-                if not os.path.exists(DATADIR):
-                    os.makedirs(DATADIR)
+                datadir = raw_input('>>>')
+                if datadir == '':
+                    datadir = os.path.join(os.path.split(__file__)[0], '__data__')
+                if not os.path.exists(datadir):
+                    os.makedirs(datadir)
                 # set as default and for this node
                 p = reg.packet()
                 p.cd(path, True)
-                p.set(nodename, DATADIR)
-                p.set('__default__', DATADIR)
+                p.set(nodename, datadir)
+                p.set('__default__', datadir)
                 yield p.send()
-                print DATADIR, "has been saved in the registry",
+                print datadir, "has been saved in the registry",
                 print "as the data location."
                 print "To change this, stop this server,"
                 print "edit the registry keys at", path,
@@ -883,35 +111,36 @@ class DataVault(LabradServer):
                 print "Press [Enter] to continue..."
                 raw_input()
                 sys.exit()
+        self.session_store = dv.SessionStore(datadir, self)
         # create root session
-        root = Session([''], self)
+        _root = self.session_store.get([''])
 
     def initContext(self, c):
         # start in the root session
         c['path'] = ['']
         # start listening to the root session
-        Session([''], self).listeners.add(c.ID)
-        
+        self.session_store.get(['']).listeners.add(c.ID)
+
     def expireContext(self, c):
         """Stop sending any signals to this context."""
         def removeFromList(ls):
             if c.ID in ls:
                 ls.remove(c.ID)
-        for session in Session.getAll():
+        for session in self.session_store.get_all():
             removeFromList(session.listeners)
             for dataset in session.datasets.values():
                 removeFromList(dataset.listeners)
                 removeFromList(dataset.param_listeners)
                 removeFromList(dataset.comment_listeners)
-        
+
     def getSession(self, c):
         """Get a session object for the current path."""
-        return Session(c['path'], self)
+        return self.session_store.get(c['path'])
 
     def getDataset(self, c):
         """Get a dataset object for the current dataset."""
         if 'dataset' not in c:
-            raise NoDatasetError()
+            raise errors.NoDatasetError()
         session = self.getSession(c)
         return session.datasets[c['dataset']]
 
@@ -924,18 +153,18 @@ class DataVault(LabradServer):
     onDataAvailable = Signal(543619, 'signal: data available', '')
     onNewParameter = Signal(543620, 'signal: new parameter', '')
     onCommentsAvailable = Signal(543621, 'signal: comments available', '')
-    
-    
+
+
     @setting(5, returns=['*s'])
     def dump_existing_sessions(self, c):
         sessions = []
-        for session in Session.getAll():
+        for session in self.session_store.geta_all():
             sessionString=''
             for s in session.path:
                 sessionString += s+'/'
             sessions.append(sessionString)
         return sessions
-    
+
     @setting(6, tagFilters=['s', '*s'], includeTags='b',
                 returns=['*s{subdirs}, *s{datasets}',
                          '*(s*s){subdirs}, *(s*s){datasets}'])
@@ -950,7 +179,7 @@ class DataVault(LabradServer):
             dirs, datasets = sess.getTags(dirs, datasets)
         #print dirs, datasets
         return dirs, datasets
-    
+
     @setting(7, path=['{get current directory}',
                       's{change into this directory}',
                       '*s{change into each directory in sequence}',
@@ -959,14 +188,14 @@ class DataVault(LabradServer):
                 returns='*s')
     def cd(self, c, path=None, create=False):
         """Change the current directory.
-        
+
         The empty string '' refers to the root directory. If the 'create' flag
         is set to true, new directories will be created as needed.
         Returns the path to the new current directory.
         """
         if path is None:
             return c['path']
-        
+
         temp = c['path'][:] # copy the current path
         if isinstance(path, (int, long)):
             if path > 0:
@@ -976,38 +205,38 @@ class DataVault(LabradServer):
         else:
             if isinstance(path, str):
                 path = [path]
-            for dir in path:
-                if dir == '':
+            for segment in path:
+                if segment == '':
                     temp = ['']
                 else:
-                    temp.append(dir)
-                if not Session.exists(temp) and not create:
-                    raise DirectoryNotFoundError(temp)
-                session = Session(temp, self) # touch the session
+                    temp.append(segment)
+                if not self.session_store.exists(temp) and not create:
+                    raise errors.DirectoryNotFoundError(temp)
+                _session = self.session_store.get(temp) # touch the session
         if c['path'] != temp:
             # stop listening to old session and start listening to new session
-            Session(c['path'], self).listeners.remove(c.ID)
-            Session(temp, self).listeners.add(c.ID)
+            self.session_store.get(c['path']).listeners.remove(c.ID)
+            self.session_store.get(temp).listeners.add(c.ID)
             c['path'] = temp
         return c['path']
-        
+
     @setting(8, name='s', returns='*s')
     def mkdir(self, c, name):
         """Make a new sub-directory in the current directory.
-        
+
         The current directory remains selected.  You must use the
         'cd' command to select the newly-created directory.
         Directory name cannot be empty.  Returns the path to the
         created directory.
         """
         if name == '':
-            raise EmptyNameError()
+            raise errors.EmptyNameError()
         path = c['path'] + [name]
-        if Session.exists(path):
-            raise DirectoryExistsError(path)
-        sess = Session(path, self) # make the new directory
+        if self.session_store.exists(path):
+            raise errors.DirectoryExistsError(path)
+        _sess = self.session_store.get(path) # make the new directory
         return path
-    
+
     @setting(9, name='s',
                 independents=['*s', '*(ss)'],
                 dependents=['*s', '*(sss)'],
@@ -1031,11 +260,11 @@ class DataVault(LabradServer):
         c['commentpos'] = 0
         c['writing'] = True
         return c['path'], c['dataset']
-    
+
     @setting(10, name=['s', 'w'], returns='(*s{path}, s{name})')
     def open(self, c, name):
         """Open a Dataset for reading.
-        
+
         You can specify the dataset by name or number.
         Returns the path and name for this dataset.
         """
@@ -1048,13 +277,13 @@ class DataVault(LabradServer):
         dataset.keepStreaming(c.ID, 0)
         dataset.keepStreamingComments(c.ID, 0)
         return c['path'], c['dataset']
-    
+
     @setting(20, data=['*v: add one row of data',
                        '*2v: add multiple rows of data'],
                  returns='')
     def add(self, c, data):
         """Add data to the current dataset.
-        
+
         The number of elements in each row of data must be equal
         to the total number of variables in the data set
         (independents + dependents).
@@ -1066,13 +295,13 @@ class DataVault(LabradServer):
             # while time.time()-start<3:
                 # yield
         if not c['writing']:
-            raise ReadOnlyError()
+            raise errors.ReadOnlyError()
         dataset.addData(data)
 
     @setting(21, limit='w', startOver='b', returns='*2v')
     def get(self, c, limit=None, startOver=False):
         """Get data from the current dataset.
-        
+
         Limit is the maximum number of rows of data to return, with
         the default being to return the whole dataset.  Setting the
         startOver flag to true will return data starting at the beginning
@@ -1084,11 +313,11 @@ class DataVault(LabradServer):
         data, c['filepos'] = dataset.getData(limit, c['filepos'])
         dataset.keepStreaming(c.ID, c['filepos'])
         return data
-    
+
     @setting(100, returns='(*(ss){independents}, *(sss){dependents})')
     def variables(self, c):
         """Get the independent and dependent variables for the current dataset.
-        
+
         Each independent variable is a cluster of (label, units).
         Each dependent variable is a cluster of (label, legend, units).
         Label is meant to be an axis label, which may be shared among several
@@ -1117,7 +346,7 @@ class DataVault(LabradServer):
         """Add a new parameter to the current dataset."""
         dataset = self.getDataset(c)
         dataset.addParameters(params)
-        
+
 
     @setting(126, 'get name', returns='s')
     def get_name(self, c):
@@ -1135,7 +364,7 @@ class DataVault(LabradServer):
     @setting(123, 'get parameters')
     def get_parameters(self, c):
         """Get all parameters.
-        
+
         Returns a cluster of (name, value) clusters, one for each parameter.
         If the set has no parameters, nothing is returned (since empty clusters
         are not allowed).
@@ -1151,7 +380,6 @@ class DataVault(LabradServer):
     @inlineCallbacks
     def read_pars_int(self, c, ctx, dataset, curdirs, subdirs=None):
         p = self.client.registry.packet(context=ctx)
-        todo = []
         for curdir, curcontent in curdirs:
             if len(curdir) > 0:
                 p.cd(curdir)
@@ -1168,7 +396,7 @@ class DataVault(LabradServer):
                     for folder in curcontent[0]:
                         p.cd(folder)
                         p.dir(key=(True, tuple(curdir+[folder])))
-                        p.cd(1)                
+                        p.cd(1)
             if len(curdir) > 0:
                 p.cd(len(curdir))
         ans = yield p.send()
@@ -1185,8 +413,7 @@ class DataVault(LabradServer):
                     yield self.read_pars_int(c, ctx, dataset, curdirs, subdirs)
                 else:
                     dataset.addParameter(' -> '.join(key[1]), item, saveNow=False)
-        
-        
+
 
     @setting(125, 'import parameters',
                   subdirs=[' : Import current directory',
@@ -1207,14 +434,14 @@ class DataVault(LabradServer):
             subdirs = -1
         yield self.read_pars_int(c, ctx, dataset, curdirs, subdirs)
         dataset.save() # make sure the new parameters get saved
-        
+
 
     @setting(200, 'add comment', comment=['s'], user=['s'], returns=[''])
     def add_comment(self, c, comment, user='anonymous'):
         """Add a comment to the current dataset."""
         dataset = self.getDataset(c)
         return dataset.addComment(user, comment)
-        
+
     @setting(201, 'get comments', limit=['w'], startOver=['b'],
                                   returns=['*(t, s{user}, s{comment})'])
     def get_comments(self, c, limit=None, startOver=False):
@@ -1260,10 +487,9 @@ class DataVault(LabradServer):
         if isinstance(datasets, str):
             datasets = [datasets]
         return sess.getTags(dirs, datasets)
-        
-        
+
+
 __server__ = DataVault()
 
 if __name__ == '__main__':
-    from labrad import util
-    util.runServer(__server__)
+    labrad.util.runServer(__server__)

--- a/data_vault.py
+++ b/data_vault.py
@@ -142,7 +142,7 @@ class DataVault(LabradServer):
         if 'dataset' not in c:
             raise errors.NoDatasetError()
         session = self.getSession(c)
-        return session.datasets[c['dataset']]
+        return session.openDataset(c['dataset'])
 
     # session signals
     onNewDir = Signal(543617, 'signal: new dir', 's')
@@ -215,7 +215,10 @@ class DataVault(LabradServer):
                 _session = self.session_store.get(temp) # touch the session
         if c['path'] != temp:
             # stop listening to old session and start listening to new session
-            self.session_store.get(c['path']).listeners.remove(c.ID)
+            try:
+                self.session_store.get(c['path']).listeners.remove(c.ID)
+            except KeyError:
+                pass
             self.session_store.get(temp).listeners.add(c.ID)
             c['path'] = temp
         return c['path']

--- a/data_vault_multihead.py
+++ b/data_vault_multihead.py
@@ -193,15 +193,12 @@ class DataVault(LabradServer):
     def getSession(self, c):
         """Get a session object for the current path."""
         return c['session']
-        #return Session(c['path'], self)
 
     def getDataset(self, c):
         """Get a dataset object for the current dataset."""
         if 'dataset' not in c:
             raise errors.NoDatasetError()
         return c['datasetObj']
-        #session = self.getSession(c)
-        #return session.datasets[c['dataset']]
 
     @setting(6, tagFilters=['s', '*s'], includeTags='b',
                 returns=['*s{subdirs}, *s{datasets}',
@@ -261,7 +258,7 @@ class DataVault(LabradServer):
             # stop listening to old session and start listening to new session
             ctx = ExtendedContext(self, c.ID)
             #print "removing %s from session %s" % (ctx, c['path'])
-            self.session_store.get(c['path']).listeners.remove(ctx)
+            c['session'].listeners.remove(ctx)
             session = self.session_store.get(temp)
             #print "Adding %s to listeners for %s" % (ctx, temp)
             session.listeners.add(ctx)

--- a/data_vault_multihead.py
+++ b/data_vault_multihead.py
@@ -34,15 +34,8 @@ from __future__ import with_statement
 
 import sys
 import os
-import warnings
-import time
 import re
-import mmap
-
-import labrad
-from labrad import constants, types as T, util
-from labrad.server import LabradServer, Signal, setting
-import labrad.wrappers
+import warnings
 
 from twisted.application.service import MultiService
 from twisted.application.internet import TCPClient
@@ -50,12 +43,19 @@ from twisted.internet import reactor
 from twisted.internet.reactor import callLater
 from twisted.internet.defer import inlineCallbacks, returnValue, maybeDeferred
 import twisted.internet.task
-from ConfigParser import SafeConfigParser
+
+import labrad
+from labrad import constants, types as T, util
+from labrad.server import LabradServer, Signal, setting
+import labrad.wrappers
+
+import datavault as dv
+from datavault import errors
 
 def lock_path(d):
     '''
     Lock a directory and return a file descriptor corresponding to the lockfile
-    
+
     This lock is non-blocking and throws an exception if it can't get the lock.
     The user is expected to fix this.
     '''
@@ -83,10 +83,7 @@ def unlock(fd):
         return
     import fcntl
     fcntl.flock(fd, fcntl.LOCK_UN)
-    
-# ConfigParser is retarded and doesn't let you choose your newline separator,
-# so we overload it to make data vault files consistent across OSes.
-# In particular, Windows expects \r\n whereas Linux uses \n
+
 class ExtendedContext(object):
     '''
     This is an extended context that contains the manager.  This prevents multiple
@@ -96,48 +93,23 @@ class ExtendedContext(object):
     def __init__(self, server, ctx):
         self.__server = server
         self.__ctx = ctx
+
     @property
     def server(self):
         return self.__server
+
     @property
     def context(self):
         return self.__ctx
 
     def __eq__(self, other):
         return (self.context == other.context) and (self.server == other.server)
+
     def __ne__(self, other):
         return not (self == other)
+
     def __hash__(self):
         return hash(self.context) ^ hash(self.server.host) ^ self.server.port
-
-class DVSafeConfigParser(SafeConfigParser):
-    def write(self, fp, newline='\r\n'):
-        """Write an .ini-format representation of the configuration state."""
-        if self._defaults:
-            fp.write("[%s]" % DEFAULTSECT + newline)
-            for (key, value) in self._defaults.items():
-                fp.write(("%s = %s" + newline) % (key, str(value).replace('\n', '\n\t')))
-            fp.write(newline)
-        for section in self._sections:
-            fp.write("[%s]" % section + newline)
-            for (key, value) in self._sections[section].items():
-                if key != "__name__":
-                    fp.write(("%s = %s" + newline) %
-                             (key, str(value).replace('\n', '\n\t')))
-            fp.write(newline)
-
-import os, re
-import time
-from datetime import datetime
-import weakref
-
-try:
-    import numpy as np
-    useNumpy = True
-except ImportError, e:
-    print e
-    print "Numpy not imported.  The DataVault will operate, but will be slower."
-    useNumpy = False
 
 
 # TODO: tagging
@@ -148,932 +120,76 @@ except ImportError, e:
 #       tag information in the session
 
 
-# location of repository will get loaded from the registry
-DATADIR = None
-
-PRECISION = 12 # digits of precision to use when saving data
-DATA_FORMAT = '%%.%dG' % PRECISION
-FILE_TIMEOUT = 60 # how long to keep datafiles open if not accessed
-DATA_TIMEOUT = 300 # how long to keep data in memory if not accessed
-TIME_FORMAT = '%Y-%m-%d, %H:%M:%S'
-
-
-## error messages
-
-class NoDatasetError(T.Error):
-    """Please open a dataset first."""
-    code = 2
-
-class DatasetNotFoundError(T.Error):
-    code = 3
-    def __init__(self, name):
-        self.msg="Dataset '%s' not found!" % name
-
-class DirectoryExistsError(T.Error):
-    code = 4
-    def __init__(self, name):
-        self.msg = "Directory '%s' already exists!" % name
-
-class DirectoryNotFoundError(T.Error):
-    code = 5
-
-class EmptyNameError(T.Error):
-    """Names of directories or keys cannot be empty"""
-    code = 6
-    def __init__(self, path):
-        self.msg = "Directory %s does not exist!" % (path,)
-        
-class ReadOnlyError(T.Error):
-    """Points can only be added to datasets created with 'new'."""
-    code = 7
-
-class BadDataError(T.Error):
-    code = 8
-    def __init__(self, varcount, gotcount):
-        self.msg = 'Dataset requires %d values per datapoint not %d.' % (varcount, gotcount)
-
-class BadParameterError(T.Error):
-    code = 9
-    def __init__(self, name):
-        self.msg = "Parameter '%s' not found." % name
-
-class ParameterInUseError(T.Error):
-    code = 10
-    def __init__(self, name):
-        self.msg = "Already a parameter called '%s'." % name
-
-
-## filename translation
-        
-encodings = [
-    ('%','%p'),
-    ('/','%f'),
-    ('\\','%b'),
-    (':','%c'),
-    ('*','%a'),
-    ('?','%q'),
-    ('"','%r'),
-    ('<','%l'),
-    ('>','%g'),
-    ('|','%v')
-]
-
-def dsEncode(name):
-    for char, code in encodings:
-        name = name.replace(char, code)
-    return name
-
-def dsDecode(name):
-    for char, code in encodings[1:] + encodings[0:1]:
-        name = name.replace(code, char)
-    return name
-
-def filedir(path):
-    return os.path.join(DATADIR, *[dsEncode(d) + '.dir' for d in path[1:]])
-    
-    
-## time formatting
-    
-def timeToStr(t):
-    return t.strftime(TIME_FORMAT)
-
-def timeFromStr(s):
-    return datetime.strptime(s, TIME_FORMAT)
-
-
-## variable parsing
-    
-re_label = re.compile(r'^([^\[(]*)') # matches up to the first [ or (
-re_legend = re.compile(r'\((.*)\)') # matches anything inside ( )
-re_units = re.compile(r'\[(.*)\]') # matches anything inside [ ]
-
-def getMatch(pat, s, default=None):
-    matches = re.findall(pat, s)
-    if len(matches) == 0:
-        if default is None:
-            raise Exception("Cannot parse '%s'." % s)
-        return default
-    return matches[0].strip()
-
-def parseIndependent(s):
-    label = getMatch(re_label, s)
-    units = getMatch(re_units, s, '')
-    return label, units
-    
-def parseDependent(s):
-    label = getMatch(re_label, s)
-    legend = getMatch(re_legend, s, '')
-    units = getMatch(re_units, s, '')
-    return label, legend, units
-    
-
-
-class Session(object):
-    """Stores information about a directory on disk.
-    
-    One session object is created for each data directory accessed.
-    The session object manages reading from and writing to the config
-    file, and manages the datasets in this directory.
-    """
-    
-    # keep a dictionary of all created session objects
-    _sessions = weakref.WeakValueDictionary()
-
-    @classmethod
-    def getAll(cls):
-        return cls._sessions.values()
-    
-    @staticmethod
-    def exists(path):
-        """Check whether a session exists on disk for a given path.
-        
-        This does not tell us whether a session object has been
-        created for that path.
-        """
-        return os.path.exists(filedir(path))
-    
-    def __new__(cls, path, hub):
-        """Get a Session object.
-        
-        If a session already exists for the given path, return it.
-        Otherwise, create a new session instance.
-        """
-        path = tuple(path)
-        if path in cls._sessions:
-            return cls._sessions[path]
-        inst = super(Session, cls).__new__(cls)
-        inst._init(path, hub)
-        cls._sessions[path] = inst
-        return inst
-
-    def _init(self, path, hub):
-        """Initialization that happens once when session object is created."""
-        self.path = path
-        self.hub = hub
-        self.dir = filedir(path)
-        self.infofile = os.path.join(self.dir, 'session.ini')
-        self.datasets = weakref.WeakValueDictionary()
-
-        if not os.path.exists(self.dir):
-            os.makedirs(self.dir)
-            
-            # notify listeners about this new directory
-            parentSession = Session(path[:-1], hub)
-            hub.onNewDir(path[-1], parentSession.listeners)
-           
-        if os.path.exists(self.infofile):
-            self.load()
-        else:
-            self.counter = 1
-            self.created = self.modified = datetime.now()
-            self.session_tags = {}
-            self.dataset_tags = {}
-
-        self.access() # update current access time and save
-        self.listeners = set()
-            
-    def load(self):
-        """Load info from the session.ini file."""
-        S = DVSafeConfigParser()
-        S.read(self.infofile)
-
-        sec = 'File System'
-        self.counter = S.getint(sec, 'Counter')
-
-        sec = 'Information'
-        self.created = timeFromStr(S.get(sec, 'Created'))
-        self.accessed = timeFromStr(S.get(sec, 'Accessed'))
-        self.modified = timeFromStr(S.get(sec, 'Modified'))
-
-        # get tags if they're there
-        if S.has_section('Tags'):
-            self.session_tags = eval(S.get('Tags', 'sessions', raw=True))
-            self.dataset_tags = eval(S.get('Tags', 'datasets', raw=True))
-        else:
-            self.session_tags = {}
-            self.dataset_tags = {}
-
-    def save(self):
-        """Save info to the session.ini file."""
-        S = DVSafeConfigParser()
-
-        sec = 'File System'
-        S.add_section(sec)
-        S.set(sec, 'Counter', repr(self.counter))
-
-        sec = 'Information'
-        S.add_section(sec)
-        S.set(sec, 'Created',  timeToStr(self.created))
-        S.set(sec, 'Accessed', timeToStr(self.accessed))
-        S.set(sec, 'Modified', timeToStr(self.modified))
-
-        sec = 'Tags'
-        S.add_section(sec)
-        S.set(sec, 'sessions', repr(self.session_tags))
-        S.set(sec, 'datasets', repr(self.dataset_tags))
-
-        with open(self.infofile, 'w') as f:
-            S.write(f)
-
-    def access(self):
-        """Update last access time and save."""
-        self.accessed = datetime.now()
-        self.save()
-
-    def listContents(self, tagFilters):
-        """Get a list of directory names in this directory."""
-        files = os.listdir(self.dir)
-        files.sort()
-        dirs = [dsDecode(s[:-4]) for s in files if s.endswith('.dir')]
-        datasets = [dsDecode(s[:-4]) for s in files if s.endswith('.csv') or s.endswith('.bin')]
-        # apply tag filters
-        def include(entries, tag, tags):
-            """Include only entries that have the specified tag."""
-            return [e for e in entries
-                    if e in tags and tag in tags[e]]
-        def exclude(entries, tag, tags):
-            """Exclude all entries that have the specified tag."""
-            return [e for e in entries
-                    if e not in tags or tag not in tags[e]]
-        for tag in tagFilters:
-            if tag[:1] == '-':
-                filter = exclude
-                tag = tag[1:]
-            else:
-                filter = include
-            #print filter.__name__ + ':', tag
-            #print 'before:', dirs, datasets
-            dirs = filter(dirs, tag, self.session_tags)
-            datasets = filter(datasets, tag, self.dataset_tags)
-            #print 'after:', dirs, datasets
-        return dirs, datasets
-            
-    def listDatasets(self):
-        """Get a list of dataset names in this directory."""
-        files = os.listdir(self.dir)
-        files.sort()
-        return [dsDecode(s[:-4]) for s in files if s.endswith('.csv') or s.endswith('.bin')]
-    
-    def newDataset(self, title, independents, dependents):
-        num = self.counter
-        self.counter += 1
-        self.modified = datetime.now()
-
-        name = '%05d - %s' % (num, title)
-        dataset = Dataset(self, name, title, create=True, independents=independents, dependents=dependents)
-        self.datasets[name] = dataset
-        self.access()
-        
-        # notify listeners about the new dataset
-        self.hub.onNewDataset(name, self.listeners)
-        return dataset
-        
-    def openDataset(self, name):
-        # first lookup by number if necessary
-        if isinstance(name, (int, long)):
-            for oldName in self.listDatasets():
-                num = int(oldName[:5])
-                if name == num:
-                    name = oldName
-                    break
-        # if it's still a number, we didn't find the set
-        if isinstance(name, (int, long)):
-            raise DatasetNotFoundError(name)
-
-        filename = dsEncode(name)
-        file_base = os.path.join(self.dir, filename)
-        if not (os.path.exists(file_base + '.csv') or os.path.exists(file_base + '.bin')):
-            raise DatasetNotFoundError(name)
-
-        if name in self.datasets:
-            dataset = self.datasets[name]
-            dataset.access()
-        else:
-            # need to create a new wrapper for this dataset
-            dataset = Dataset(self, name)
-            self.datasets[name] = dataset
-        self.access()
-        
-        return dataset
-
-    def updateTags(self, tags, sessions, datasets):
-        def updateTagDict(tags, entries, d):
-            updates = []
-            for entry in entries:
-                changed = False
-                if entry not in d:
-                    d[entry] = set()
-                entryTags = d[entry]
-                for tag in tags:
-                    if tag[:1] == '-':
-                        # remove this tag
-                        tag = tag[1:]
-                        if tag in entryTags:
-                            entryTags.remove(tag)
-                            changed = True
-                    elif tag[:1] == '^':
-                        # toggle this tag
-                        tag = tag[1:]
-                        if tag in entryTags:
-                            entryTags.remove(tag)
-                        else:
-                            entryTags.add(tag)
-                        changed = True
-                    else:
-                        # add this tag
-                        if tag not in entryTags:
-                            entryTags.add(tag)
-                            changed = True
-                if changed:
-                    updates.append((entry, sorted(entryTags)))
-            return updates
-
-        sessUpdates = updateTagDict(tags, sessions, self.session_tags)
-        dataUpdates = updateTagDict(tags, datasets, self.dataset_tags)
-
-        self.access()
-        if len(sessUpdates) + len(dataUpdates):
-            # fire a message about the new tags
-            msg = (sessUpdates, dataUpdates)
-            self.hub.onTagsUpdated(msg, self.listeners)
-
-    def getTags(self, sessions, datasets):
-        sessTags = [(s, sorted(self.session_tags.get(s, []))) for s in sessions]
-        dataTags = [(d, sorted(self.dataset_tags.get(d, []))) for d in datasets]
-        return sessTags, dataTags
-
-class SelfClosingFile(object):
-    """
-    A container for a file object that closes the underlying file handle if not
-    accessed within a specified timeout. Call this container to get the file handle.
-    """
-    def __init__(self, filename, mode, timeout=FILE_TIMEOUT, touch=True):
-        self.filename = filename
-        self.mode = mode
-        self.timeout = timeout
-        self.callbacks = []
-        if touch:
-            self.__call__()
-
-    def __call__(self):
-        if not hasattr(self, '_file'):
-            self._file = open(self.filename, self.mode)
-            self._fileTimeoutCall = callLater(self.timeout, self._fileTimeout)
-        else:
-            self._fileTimeoutCall.reset(self.timeout)
-        return self._file
-
-    def _fileTimeout(self):
-        for callback in self.callbacks:
-            callback(self)
-        self._file.close()
-        del self._file
-        del self._fileTimeoutCall
-
-    def size(self):
-        return os.fstat(self().fileno()).st_size
-
-    def onClose(self, callback):
-        self.callbacks.append(callback)
-
-class CsvListData(object):
-    """
-    Data backed by a csv-formatted file.
-    
-    Stores the entire contents of the file in memory as a list or numpy array
-    """
-    
-    def __init__(self, filename, cols):
-        self.filename = filename
-        self._file = SelfClosingFile(filename, 'a+')
-        self.cols = cols
-    
-    @property
-    def file(self):
-        return self._file()
-    
-    @property
-    def data(self):
-        """Read data from file on demand.
-        
-        The data is scheduled to be cleared from memory unless accessed."""
-        if not hasattr(self, '_data'):
-            self._data = []
-            self._datapos = 0
-            self._dataTimeoutCall = callLater(DATA_TIMEOUT, self._dataTimeout)
-        else:
-            self._dataTimeoutCall.reset(DATA_TIMEOUT)
-        f = self.file
-        f.seek(self._datapos)
-        lines = f.readlines()
-        self._data.extend([float(n) for n in line.split(',')] for line in lines)
-        self._datapos = f.tell()
-        return self._data
-    
-    def _dataTimeout(self):
-        del self._data
-        del self._datapos
-        del self._dataTimeoutCall
-    
-    def _saveData(self, data):
-        f = self.file
-        for row in data:
-            # always save with dos linebreaks
-            f.write(', '.join(DATA_FORMAT % v for v in row) + '\r\n')
-        f.flush()
-    
-    def addData(self, data):
-        if not len(data) or not isinstance(data[0], list):
-            data = [data]
-        if len(data[0]) != self.cols:
-            raise BadDataError(self.cols, len(data[0]))
-            
-        # append the data to the file
-        self._saveData(data)
-    
-    def getData(self, limit, start):
-        if limit is None:
-            data = self.data[start:]
-        else:
-            data = self.data[start:start+limit]
-        return data, start + len(data)
-    
-    def hasMore(self, pos):
-        return pos < len(self.data)
-
-class CsvNumpyData(CsvListData):
-    """
-    Data backed by a csv-formatted file.
-    
-    Stores the entire contents of the file in memory as a list or numpy array
-    """
-    
-    def __init__(self, filename, cols):
-        self.filename = filename
-        self._file = SelfClosingFile(filename, 'rw')
-        self.cols = cols
-    
-    @property
-    def file(self):
-        return self._file()
-
-    def _get_data(self):
-        """Read data from file on demand.
-        
-        The data is scheduled to be cleared from memory unless accessed."""
-        if not hasattr(self, '_data'):
-            try:
-                # if the file is empty, this line can barf in certain versions
-                # of numpy.  Clearly, if the file does not exist on disk, this
-                # will be the case.  Even if the file exists on disk, we must
-                # check its size
-                if self._file.size() > 0:
-                    self._data = np.loadtxt(self.file, delimiter=',')
-                else:
-                    self._data = np.array([[]])
-                if len(self._data.shape) == 1:
-                    self._data.shape = (1, len(self._data))
-            except ValueError:
-                # no data saved yet
-                # this error is raised by numpy <=1.2
-                self._data = np.array([[]])
-            except IOError:
-                # no data saved yet
-                # this error is raised by numpy 1.3
-                self.file.seek(0)
-                self._data = np.array([[]])
-            self._dataTimeoutCall = callLater(DATA_TIMEOUT, self._dataTimeout)
-        else:
-            self._dataTimeoutCall.reset(DATA_TIMEOUT)
-        return self._data
-
-    def _set_data(self, data):
-        self._data = data
-        
-    data = property(_get_data, _set_data)
-        
-    def _dataTimeout(self):
-        del self._data
-        del self._dataTimeoutCall
-        
-    def _saveData(self, data):
-        f = self.file
-        # always save with dos linebreaks (requires numpy 1.5.0 or greater)
-        np.savetxt(f, data, fmt=DATA_FORMAT, delimiter=',', newline='\r\n')
-        f.flush()
-        
-    def addData(self, data):
-        data = np.asarray(data)
-        
-        # reshape single row
-        if len(data.shape) == 1:
-            data.shape = (1, data.size)
-        
-        # check row length
-        if data.shape[-1] != self.cols:
-            raise BadDataError(self.cols, data.shape[-1])
-        
-        # append data to in-memory data
-        if self.data.size > 0:
-            self.data = np.vstack((self.data, data))
-        else:
-            self.data = data
-            
-        # append data to file
-        self._saveData(data)
-    
-    def getData(self, limit, start):
-        if limit is None:
-            data = self.data[start:]
-        else:
-            data = self.data[start:start+limit]
-        # nrows should be zero for an empty row
-        nrows = len(data) if data.size > 0 else 0
-        return data, start + nrows
-        
-    def hasMore(self, pos):
-        # cheesy hack: if pos == 0, we only need to check whether
-        # the filesize is nonzero
-        if pos == 0:
-            return os.path.getsize(self.filename) > 0
-        else:
-            nrows = len(self.data) if self.data.size > 0 else 0
-            return pos < nrows
-
-class BinaryData(object):
-    """
-    Data backed by a binary-formatted file.
-    
-    The file is memory-mapped to take advantage of os-level memory paging.
-    """
-    
-    def __init__(self, filename, cols):
-        self._file = SelfClosingFile(filename, 'a+b')
-        self._file.onClose(self._closeMap)
-        self.cols = cols
-        self.rowBytes = cols * 8
-
-    @property
-    def file(self):
-        return self._file()
-
-    @property
-    def data(self):
-        if not hasattr(self, '_mmap'):
-            f = self.file
-            self._mmap = mmap.mmap(f.fileno(), self._file.size())
-        return self._mmap
-    
-    def _closeMap(self, *args):
-        if hasattr(self, '_mmap'):
-            self._mmap.close()
-            del self._mmap
-            
-    def addData(self, data):
-        data = np.asarray(data, dtype='>f8')
-        
-        # reshape single row
-        if len(data.shape) == 1:
-            data.shape = (1, data.size)
-        
-        # check row length
-        if data.shape[-1] != self.cols:
-            raise BadDataError(self.cols, data.shape[-1])
-        
-        # append data to memory map
-        bytes = data.tostring('C')
-        f = self.file
-        f.seek(self._file.size())
-        f.write(bytes)
-        f.flush()
-        self._closeMap() # close the mmap since we can't resize. TODO: check whether we can mremap
-    
-    def getData(self, limit, start):
-        size = self._file.size()
-        if size == 0:
-            return [], 0
-        startOfs = start * self.rowBytes
-        if limit is None:
-            bytes = self.data[startOfs:]
-        else:
-            endOfs = startOfs + limit * self.rowBytes
-            bytes = self.data[startOfs:endOfs]
-        data = np.reshape(np.fromstring(bytes, dtype='>f8'), [-1, self.cols])
-        # nrows should be zero for an empty row
-        nrows = len(data) if data.size > 0 else 0
-        return data, start + nrows
-        
-    def hasMore(self, pos):
-        nrows = self._file.size() / self.rowBytes
-        return pos < nrows
-
-def makeData(filename, cols):
-    """Make a data object that manages in-memory and on-disk storage for a dataset."""
-    csv_file = filename + '.csv'
-    bin_file = filename + '.bin'
-    if os.path.exists(csv_file):
-        if useNumpy:
-            return CsvNumpyData(csv_file, cols)
-        else:
-            return CsvListData(csv_file, cols)
-    else:
-        return BinaryData(bin_file, cols)
-
-class Dataset(object):
-    def __init__(self, session, name, title=None, num=None, create=False, independents=[], dependents=[]):
-        self.hub = session.hub
-        self.name = name
-        file_base = os.path.join(session.dir, dsEncode(name))
-        self.infofile = file_base + '.ini'
-        self.listeners = set() # contexts that want to hear about added data
-        self.param_listeners = set()
-        self.comment_listeners = set()
-        
-        if create:
-            self.title = title
-            self.created = self.accessed = self.modified = datetime.now()
-            self.independents = [self.makeIndependent(i) for i in independents]
-            self.dependents = [self.makeDependent(d) for d in dependents]
-            self.parameters = []
-            self.comments = []
-            self.save()
-        else:
-            self.load()
-            self.access()
-
-        self.data = makeData(file_base, cols=len(self.independents) + len(self.dependents))
-
-    def load(self):
-        S = DVSafeConfigParser()
-        S.read(self.infofile)
-
-        gen = 'General'
-        self.title = S.get(gen, 'Title', raw=True)
-        self.created = timeFromStr(S.get(gen, 'Created'))
-        self.accessed = timeFromStr(S.get(gen, 'Accessed'))
-        self.modified = timeFromStr(S.get(gen, 'Modified'))
-
-        def getInd(i):
-            sec = 'Independent %d' % (i+1)
-            label = S.get(sec, 'Label', raw=True)
-            units = S.get(sec, 'Units', raw=True)
-            return dict(label=label, units=units)
-        count = S.getint(gen, 'Independent')
-        self.independents = [getInd(i) for i in range(count)]
-
-        def getDep(i):
-            sec = 'Dependent %d' % (i+1)
-            label = S.get(sec, 'Label', raw=True)
-            units = S.get(sec, 'Units', raw=True)
-            categ = S.get(sec, 'Category', raw=True)
-            return dict(label=label, units=units, category=categ)
-        count = S.getint(gen, 'Dependent')
-        self.dependents = [getDep(i) for i in range(count)]
-
-        def getPar(i):
-            sec = 'Parameter %d' % (i+1)
-            label = S.get(sec, 'Label', raw=True)
-            # TODO: big security hole! eval can execute arbitrary code
-            data = T.evalLRData(S.get(sec, 'Data', raw=True))
-            return dict(label=label, data=data)
-        count = S.getint(gen, 'Parameters')
-        self.parameters = [getPar(i) for i in range(count)]
-
-        # get comments if they're there
-        if S.has_section('Comments'):
-            def getComment(i):
-                sec = 'Comments'
-                time, user, comment = eval(S.get(sec, 'c%d' % i, raw=True))
-                return timeFromStr(time), user, comment
-            count = S.getint(gen, 'Comments')
-            self.comments = [getComment(i) for i in range(count)]
-        else:
-            self.comments = []
-        
-    def save(self):
-        S = DVSafeConfigParser()
-        
-        sec = 'General'
-        S.add_section(sec)
-        S.set(sec, 'Created',  timeToStr(self.created))
-        S.set(sec, 'Accessed', timeToStr(self.accessed))
-        S.set(sec, 'Modified', timeToStr(self.modified))
-        S.set(sec, 'Title',       self.title)
-        S.set(sec, 'Independent', repr(len(self.independents)))
-        S.set(sec, 'Dependent',   repr(len(self.dependents)))
-        S.set(sec, 'Parameters',  repr(len(self.parameters)))
-        S.set(sec, 'Comments',    repr(len(self.comments)))
-
-        for i, ind in enumerate(self.independents):
-            sec = 'Independent %d' % (i+1)
-            S.add_section(sec)
-            S.set(sec, 'Label', ind['label'])
-            S.set(sec, 'Units', ind['units'])
-
-        for i, dep in enumerate(self.dependents):
-            sec = 'Dependent %d' % (i+1)
-            S.add_section(sec)
-            S.set(sec, 'Label',    dep['label'])
-            S.set(sec, 'Units',    dep['units'])
-            S.set(sec, 'Category', dep['category'])
-
-        for i, par in enumerate(self.parameters):
-            sec = 'Parameter %d' % (i+1)
-            S.add_section(sec)
-            S.set(sec, 'Label', par['label'])
-            # TODO: smarter saving here, since eval'ing is insecure
-            S.set(sec, 'Data', repr(par['data']))
-
-        sec = 'Comments'
-        S.add_section(sec)
-        for i, (time, user, comment) in enumerate(self.comments):
-            time = timeToStr(time)
-            S.set(sec, 'c%d' % i, repr((time, user, comment)))
-            
-        with open(self.infofile, 'w') as f:
-            S.write(f)
-
-    def access(self):
-        """Update time of last access for this dataset."""
-        self.accessed = datetime.now()
-        self.save()
-        
-    def makeIndependent(self, label):
-        """Add an independent variable to this dataset."""
-        if isinstance(label, tuple):
-            label, units = label
-        else:
-            label, units = parseIndependent(label)
-        return dict(label=label, units=units)
-
-    def makeDependent(self, label):
-        """Add a dependent variable to this dataset."""
-        if isinstance(label, tuple):
-            label, legend, units = label
-        else:
-            label, legend, units = parseDependent(label)
-        return dict(category=label, label=legend, units=units)
-
-    def addParameter(self, name, data, saveNow=True):
-        self._addParam(name, data)
-        if saveNow:
-            self.save()
-        
-        # notify all listening contexts
-        self.hub.onNewParameter(None, self.param_listeners)
-        self.param_listeners = set()
-        return name
-
-    def addParameters(self, params, saveNow=True):
-        for name, data in params:
-            self._addParam(name, data)
-        if saveNow:
-            self.save()
-        
-        # notify all listening contexts
-        self.hub.onNewParameter(None, self.param_listeners)
-        self.param_listeners = set()
-        
-    def _addParam(self, name, data):
-        for p in self.parameters:
-            if p['label'] == name:
-                raise ParameterInUseError(name)
-        d = dict(label=name, data=data)
-        self.parameters.append(d)
-        
-    def getParameter(self, name, case_sensitive=True):
-        for p in self.parameters:
-            if case_sensitive:
-                if p['label'] == name:
-                    return p['data']
-            else:
-                if p['label'].lower() == name.lower():
-                    return p['data']
-        raise BadParameterError(name)
-        
-    def addData(self, data):
-        # append the data to the file
-        self.data.addData(data)
-        
-        # notify all listening contexts
-        self.hub.onDataAvailable(None, self.listeners)
-        self.listeners = set()
-    
-    def getData(self, limit, start):
-        return self.data.getData(limit, start)
-        
-    def keepStreaming(self, context, pos):
-        # keepStreaming does something a bit odd and has a confusing name (ERJ)
-        #
-        # The goal is this: a client that is listening for "new data" events should only
-        # receive a single notification even if there are multiple writes.  To do this,
-        # we do the following:
-        #
-        # If a client reads to the end of the dataset, it is added to the list to be notified
-        # if another context does 'addData'.
-        #
-        # if a client calls 'addData', all listeners are notified, and then the set of listeners
-        # is cleared.
-        # 
-        # If a client reads, but not to the end of the dataset, it is immediately notified that
-        # there is more data for it to read, and then removed from the set of notifiers.
-        if self.data.hasMore(pos):
-            if context in self.listeners:
-                self.listeners.remove(context)
-            self.hub.onDataAvailable(None, [context])
-        else:
-            self.listeners.add(context)
-            
-    def addComment(self, user, comment):
-        self.comments.append((datetime.now(), user, comment))
-        self.save()
-        
-        # notify all listening contexts
-        self.hub.onCommentsAvailable(None, self.comment_listeners)
-        self.comment_listeners = set()
-
-    def getComments(self, limit, start):
-        if limit is None:
-            comments = self.comments[start:]
-        else:
-            comments = self.comments[start:start+limit]
-        return comments, start + len(comments)
-        
-    def keepStreamingComments(self, context, pos):
-        if pos < len(self.comments):
-            if context in self.comment_listeners:
-                self.comment_listeners.remove(context)
-            self.hub.onCommentsAvailable(None, [context])
-        else:
-            self.comment_listeners.add(context)
-
 # One instance per manager.  Not persistent, recreated when connection is lost/regained
 class DataVault(LabradServer):
     name = 'Data Vault'
-    
-    def __init__(self, host, port, password, hub, path):
+
+    def __init__(self, host, port, password, hub, path, session_store):
         LabradServer.__init__(self)
         self.host = host
         self.port = port
         self.password = password
         self.hub = hub
         self.path = path
+        self.session_store = session_store
         self.alive = False
+
+        # session signals
         self.onNewDir = Signal(543617, 'signal: new dir', 's')
         self.onNewDataset = Signal(543618, 'signal: new dataset', 's')
         self.onTagsUpdated = Signal(543622, 'signal: tags updated', '*(s*s)*(s*s)')
 
-    # dataset signals
+        # dataset signals
         self.onDataAvailable = Signal(543619, 'signal: data available', '')
         self.onNewParameter = Signal(543620, 'signal: new parameter', '')
         self.onCommentsAvailable = Signal(543621, 'signal: comments available', '')
-    
+
     def initServer(self):
         # let the DataVaultHost know that we connected
         self.hub.connect(self)
         # create root session
         self.alive = True
-        root = Session([''], self.hub)
+        _root = self.session_store.get([''])
         self.keepalive_timer = twisted.internet.task.LoopingCall(self.keepalive)
         self.onShutdown().addBoth(self.end_keepalive)
         self.keepalive_timer.start(120)
-        
+
     def end_keepalive(self, *ignored):
         # stopServer is only called when the whole application shuts down.
         # We need to manually use the onShutdown() callback
         self.keepalive_timer.stop()
-    
+
+    @inlineCallbacks
     def keepalive(self):
         print "sending keepalive to %s:%d" % (self.host, self.port)
         p = self.client.manager.packet()
         p.echo('123')
-        d = p.send()
-        def finished(result):
-            return 0
-        d.addBoth(finished) # We don't care about the result, dropped connections will be recognized automatically
-        return d
+        try:
+            yield p.send()
+        except:
+            pass # We don't care about errors, dropped connections will be recognized automatically
 
     def initContext(self, c):
         # start in the root session
         c['path'] = ['']
         # start listening to the root session
-        c['session'] = Session([''], self.hub)
+        c['session'] = self.session_store.get([''])
         c['session'].listeners.add(ExtendedContext(self, c.ID))
         #print "Adding %s to listeners for %s" % (c.ID, [''])
-        
+
     def expireContext(self, c):
         """Stop sending any signals to this context."""
         ctx = ExtendedContext(self, c.ID)
         def removeFromList(ls):
             if ctx in ls:
                 ls.remove(ctx)
-        for session in Session.getAll():
+        for session in self.session_store.get_all():
             removeFromList(session.listeners)
             for dataset in session.datasets.values():
                 removeFromList(dataset.listeners)
                 removeFromList(dataset.param_listeners)
                 removeFromList(dataset.comment_listeners)
-        
+
     def getSession(self, c):
         """Get a session object for the current path."""
         return c['session']
@@ -1082,21 +198,11 @@ class DataVault(LabradServer):
     def getDataset(self, c):
         """Get a dataset object for the current dataset."""
         if 'dataset' not in c:
-            raise NoDatasetError()
+            raise errors.NoDatasetError()
         return c['datasetObj']
         #session = self.getSession(c)
         #return session.datasets[c['dataset']]
 
-    # session signals
-    #onNewDir = Signal(543617, 'signal: new dir', 's')
-    #onNewDataset = Signal(543618, 'signal: new dataset', 's')
-    #onTagsUpdated = Signal(543622, 'signal: tags updated', '*(s*s)*(s*s)')
-
-    # dataset signals
-    #onDataAvailable = Signal(543619, 'signal: data available', '')
-    #onNewParameter = Signal(543620, 'signal: new parameter', '')
-    #onCommentsAvailable = Signal(543621, 'signal: comments available', '')
-    
     @setting(6, tagFilters=['s', '*s'], includeTags='b',
                 returns=['*s{subdirs}, *s{datasets}',
                          '*(s*s){subdirs}, *(s*s){datasets}'])
@@ -1111,7 +217,7 @@ class DataVault(LabradServer):
             dirs, datasets = sess.getTags(dirs, datasets)
         #print dirs, datasets
         return dirs, datasets
-    
+
     @setting(7, target = ['       : {get current directory}',
                           's      : {change into this directory}',
                           '*s     : {change into each directory in sequence}',
@@ -1121,7 +227,7 @@ class DataVault(LabradServer):
                 returns='*s')
     def cd(self, c, target=None):
         """Change the current directory.
-        
+
         The empty string '' refers to the root directory. If the 'create' flag
         is set to true, new directories will be created as needed.
         Returns the path to the new current directory.
@@ -1143,43 +249,43 @@ class DataVault(LabradServer):
         else:
             if isinstance(path, str):
                 path = [path]
-            for dir in path:
-                if dir == '':
+            for segment in path:
+                if segment == '':
                     temp = ['']
                 else:
-                    temp.append(dir)
-                if not Session.exists(temp) and not create:
-                    raise DirectoryNotFoundError(temp)
-                session = Session(temp, self.hub) # touch the session
+                    temp.append(segment)
+                if not self.session_store.exists(temp) and not create:
+                    raise errors.DirectoryNotFoundError(temp)
+                session = self.session_store.get(temp) # touch the session
         if c['path'] != temp:
             # stop listening to old session and start listening to new session
             ctx = ExtendedContext(self, c.ID)
             #print "removing %s from session %s" % (ctx, c['path'])
-            Session(c['path'], self.hub).listeners.remove(ctx)
-            session = Session(temp, self.hub)
+            self.session_store.get(c['path']).listeners.remove(ctx)
+            session = self.session_store.get(temp)
             #print "Adding %s to listeners for %s" % (ctx, temp)
             session.listeners.add(ctx)
             c['session'] = session
             c['path'] = temp
         return c['path']
-        
+
     @setting(8, name='s', returns='*s')
     def mkdir(self, c, name):
         """Make a new sub-directory in the current directory.
-        
+
         The current directory remains selected.  You must use the
         'cd' command to select the newly-created directory.
         Directory name cannot be empty.  Returns the path to the
         created directory.
         """
         if name == '':
-            raise EmptyNameError()
+            raise errors.EmptyNameError()
         path = c['path'] + [name]
-        if Session.exists(path):
-            raise DirectoryExistsError(path)
-        sess = Session(path, self.hub) # make the new directory
+        if self.session_store.exists(path):
+            raise errors.DirectoryExistsError(path)
+        _sess = self.session_store.get(path) # make the new directory
         return path
-    
+
     @setting(9, name='s',
                 independents=['*s', '*(ss)'],
                 dependents=['*s', '*(sss)'],
@@ -1204,11 +310,11 @@ class DataVault(LabradServer):
         c['commentpos'] = 0
         c['writing'] = True
         return c['path'], c['dataset']
-    
+
     @setting(10, name=['s', 'w'], returns='(*s{path}, s{name})')
     def open(self, c, name):
         """Open a Dataset for reading.
-        
+
         You can specify the dataset by name or number.
         Returns the path and name for this dataset.
         """
@@ -1223,26 +329,26 @@ class DataVault(LabradServer):
         dataset.keepStreaming(ctx, 0)
         dataset.keepStreamingComments(ctx, 0)
         return c['path'], c['dataset']
-    
+
     @setting(20, data=['*v: add one row of data',
                        '*2v: add multiple rows of data'],
                  returns='')
     def add(self, c, data):
         """Add data to the current dataset.
-        
+
         The number of elements in each row of data must be equal
         to the total number of variables in the data set
         (independents + dependents).
         """
         dataset = self.getDataset(c)
         if not c['writing']:
-            raise ReadOnlyError()
+            raise errors.ReadOnlyError()
         dataset.addData(data)
 
     @setting(21, limit='w', startOver='b', returns='*2v')
     def get(self, c, limit=None, startOver=False):
         """Get data from the current dataset.
-        
+
         Limit is the maximum number of rows of data to return, with
         the default being to return the whole dataset.  Setting the
         startOver flag to true will return data starting at the beginning
@@ -1255,11 +361,11 @@ class DataVault(LabradServer):
         ctx = ExtendedContext(self, c.ID)
         dataset.keepStreaming(ctx, c['filepos'])
         return data
-    
+
     @setting(100, returns='(*(ss){independents}, *(sss){dependents})')
     def variables(self, c):
         """Get the independent and dependent variables for the current dataset.
-        
+
         Each independent variable is a cluster of (label, units).
         Each dependent variable is a cluster of (label, legend, units).
         Label is meant to be an axis label, which may be shared among several
@@ -1274,7 +380,7 @@ class DataVault(LabradServer):
     def parameters(self, c):
         """Get a list of parameter names."""
         dataset = self.getDataset(c)
-        ctx = ExtendedContext(self, c)
+        ctx = ExtendedContext(self, c.ID)
         dataset.param_listeners.add(ctx) # send a message when new parameters are added
         return [par['label'] for par in dataset.parameters]
 
@@ -1293,7 +399,7 @@ class DataVault(LabradServer):
     @setting(123, 'get parameters')
     def get_parameters(self, c):
         """Get all parameters.
-        
+
         Returns a cluster of (name, value) clusters, one for each parameter.
         If the set has no parameters, nothing is returned (since empty clusters
         are not allowed).
@@ -1315,7 +421,6 @@ class DataVault(LabradServer):
     @inlineCallbacks
     def read_pars_int(self, c, ctx, dataset, curdirs, subdirs=None):
         p = self.client.registry.packet(context=ctx)
-        todo = []
         for curdir, curcontent in curdirs:
             if len(curdir) > 0:
                 p.cd(curdir)
@@ -1349,8 +454,7 @@ class DataVault(LabradServer):
                     yield self.read_pars_int(c, ctx, dataset, curdirs, subdirs)
                 else:
                     dataset.addParameter(' -> '.join(key[1]), item, saveNow=False)
-        
-        
+
 
     @setting(125, 'import parameters',
                   subdirs=[': Import current directory',
@@ -1371,7 +475,7 @@ class DataVault(LabradServer):
             subdirs = -1
         yield self.read_pars_int(c, ctx, dataset, curdirs, subdirs)
         dataset.save() # make sure the new parameters get saved
- 
+
     @setting(126, 'get name', returns='s')
     def get_name(self, c):
         """Get the name of the current dataset."""
@@ -1384,7 +488,7 @@ class DataVault(LabradServer):
         """Add a comment to the current dataset."""
         dataset = self.getDataset(c)
         return dataset.addComment(user, comment)
-        
+
     @setting(201, 'get comments', limit='w', startOver='b',
                                   returns='*(t, s{user}, s{comment})')
     def get_comments(self, c, limit=None, startOver=False):
@@ -1453,7 +557,7 @@ class DataVault(LabradServer):
         """
         port = port or self.port
         password = password or self.password
-        dvc = DataVaultConnector(host, port, password, self.hub, self.path)
+        dvc = DataVaultConnector(host, port, password, self.hub, self.path, self.session_store)
         dvc.setServiceParent(self.hub)
         #self.hub.addService(DataVaultConnector(host, port, password, self.hub, self.path))
 
@@ -1477,20 +581,21 @@ class DataVault(LabradServer):
 # One instance per manager, persistant (not recreated when connections are dropped)
 class DataVaultConnector(MultiService):
     """Service that connects the Data Vault to a single LabRAD manager
-    
+
     If the manager is stopped or we lose the network connection,
     this service attempts to reconnect so that we will come
     back online when the manager is back up.
     """
     reconnectDelay = 10
-    
-    def __init__(self, host, port, password, hub, path):
+
+    def __init__(self, host, port, password, hub, path, session_store):
         MultiService.__init__(self)
         self.host = host
         self.port = port
         self.password = password
         self.hub = hub
         self.path = path
+        self.session_store = session_store
         self.die = False
 
     def startService(self):
@@ -1500,12 +605,12 @@ class DataVaultConnector(MultiService):
     def startConnection(self):
         """Attempt to start the data vault and connect to LabRAD."""
         print 'Connecting to %s:%d...' % (self.host, self.port)
-        self.server = DataVault(self.host, self.port, self.password, self.hub, self.path)
+        self.server = DataVault(self.host, self.port, self.password, self.hub, self.path, self.session_store)
         self.server.onStartup().addErrback(self._error)
         self.server.onShutdown().addCallbacks(self._disconnected, self._error)
         self.cxn = TCPClient(self.host, self.port, self.server)
         self.addService(self.cxn)
-        
+
     def _disconnected(self, data):
         print 'Disconnected from %s:%d.' % (self.host, self.port)
         self.hub.disconnect(self.server)
@@ -1528,18 +633,18 @@ class DataVaultConnector(MultiService):
             self.removeService(self.cxn)
             del self.cxn
         if self.die:
-            print "Connecting terminating permanetly"
+            print "Connecting terminating permanently"
             self.stopService()
             self.disownServiceParent()
             return False
         else:
             reactor.callLater(self.reconnectDelay, self.startConnection)
             print 'Will try to reconnect to %s:%d in %d seconds...' % (self.host, self.port, self.reconnectDelay)
-    
+
 # Hub object: one instance total
 class DataVaultServiceHost(MultiService):
     """Parent Service that manages multiple child DataVaultConnector's"""
-    
+
     signals = [
         'onNewDir',
         'onNewDataset',
@@ -1548,33 +653,33 @@ class DataVaultServiceHost(MultiService):
         'onNewParameter',
         'onCommentsAvailable'
     ]
-    
+
     def __init__(self, path, managers):
         MultiService.__init__(self)
-        self.path = path        
+        self.path = path
         self.managers = managers
         self.servers = set()
+        self.session_store = dv.SessionStore(path, self)
         for signal in self.signals:
             self.wrapSignal(signal)
         for host, port, password in managers:
-            x = DataVaultConnector(host, port, password, self, self.path)
+            x = DataVaultConnector(host, port, password, self, self.path, self.session_store)
             x.setServiceParent(self)
             #self.addService(DataVaultConnector(host, port, password, self, self.path))
-    
+
     def connect(self, server):
         print 'server connected: %s:%d' % (server.host, server.port)
         self.servers.add(server)
-    
+
     def disconnect(self, server):
         print 'server disconnected: %s:%d' % (server.host, server.port)
         if server in self.servers:
             self.servers.remove(server)
-    
+
     def reconnect(self, host_regex, port=0):
         '''
         Drop the connection to the specified host(s).  They will auto-reconnect.
         '''
-
         for s in self.servers:
             if re.match(host_regex, s.host) and (port == 0 or s.port==port):
                 s._cxn.disconnect()
@@ -1615,7 +720,6 @@ class DataVaultServiceHost(MultiService):
         # to the "primary" manager.
 
         cxn = yield labrad.wrappers.connectAsync()
-        reg = cxn.registry
         path = ['', 'Servers', 'Data Vault', 'Multihead']
         reg = cxn.registry
         p = reg.packet()
@@ -1631,7 +735,7 @@ class DataVaultServiceHost(MultiService):
                 if connector.host == host and connector.port == port:
                     break
             else:
-                dvc = DataVaultConnector(host, port, password, self, self.path)
+                dvc = DataVaultConnector(host, port, password, self, self.path, self.session_store)
                 dvc.setServiceParent(self)
                 #self.addService(DataVaultConnector(host, port, password, self, self.path))
 
@@ -1641,7 +745,7 @@ class DataVaultServiceHost(MultiService):
     def __str__(self):
         managers = ['%s:%d' % (connector.host, connector.port) for connector in self]
         return 'DataVaultServiceHost(%s)' % (managers,) 
-    
+
     def wrapSignal(self, signal):
         print 'wrapping signal:', signal
         def relay(data, contexts=None, tag=None):
@@ -1666,7 +770,6 @@ def load_settings_registry(cxn):
     on any other host.  This should prevent ever having two copies of the
     datavault running.
     '''
-    reg = cxn.registry
     path = ['', 'Servers', 'Data Vault', 'Multihead']
     reg = cxn.registry
     # try to load for this node
@@ -1701,8 +804,6 @@ def load_settings_cmdline(argv):
 
 def start_server(args):
     path, managers = args
-    global DATADIR
-    DATADIR = path
     if not os.path.exists(path):
         raise Exception('data path %s does not exist' % path)
     if not os.path.isdir(path):
@@ -1720,20 +821,23 @@ def start_server(args):
     managers = [parseManagerInfo(m) for m in managers]
     service = DataVaultServiceHost(path, managers)
     service.startService()
-    
-def main(argv=sys.argv):
-    if len(argv) > 1 and argv[1] == '--auto':
-        d = labrad.wrappers.connectAsync()
-        d.addCallback(load_settings_registry)
-    else:
-        d = maybeDeferred(load_settings_cmdline, argv)
-    def usage(err):
-        print err.getErrorMessage()
-        print 'usage: %s /path/to/vault/directory [password@]host[:port] [password2]@host2[:port2] ...' % (argv[0])
-        reactor.callWhenRunning(reactor.stop)
 
-    d.addCallback(start_server)
-    d.addErrback(usage)
+def main(argv=sys.argv):
+    @inlineCallbacks
+    def start():
+        try:
+            if len(argv) > 1 and argv[1] == '--auto':
+                cxn = yield labrad.wrappers.connectAsync()
+                settings = yield load_settings_registry(cxn)
+            else:
+                settings = load_settings_cmdline(argv)
+            start_server(settings)
+        except Exception as e:
+            print e
+            print 'usage: %s /path/to/vault/directory [password@]host[:port] [password2]@host2[:port2] ...' % (argv[0])
+            reactor.callWhenRunning(reactor.stop)
+
+    _ = start()
     reactor.run()
 
 if __name__ == '__main__':

--- a/datavault/__init__.py
+++ b/datavault/__init__.py
@@ -108,7 +108,7 @@ class SessionStore(object):
         path = tuple(path)
         if path in self._sessions:
             return self._sessions[path]
-        session = Session(self.datadir, path, self.hub)
+        session = Session(self.datadir, path, self.hub, self)
         self._sessions[path] = session
         return session
 
@@ -121,7 +121,7 @@ class Session(object):
     file, and manages the datasets in this directory.
     """
 
-    def __init__(self, datadir, path, hub):
+    def __init__(self, datadir, path, hub, session_store):
         """Initialization that happens once when session object is created."""
         self.path = path
         self.hub = hub
@@ -133,7 +133,7 @@ class Session(object):
             os.makedirs(self.dir)
 
             # notify listeners about this new directory
-            parent_session = Session(datadir, path[:-1], hub)
+            parent_session = session_store.get(path[:-1])
             hub.onNewDir(path[-1], parent_session.listeners)
 
         if os.path.exists(self.infofile):

--- a/datavault/__init__.py
+++ b/datavault/__init__.py
@@ -1,0 +1,541 @@
+from datetime import datetime
+import os
+import re
+import weakref
+
+from labrad import types as T
+
+from . import backend, errors, util
+
+
+## Filename translation.
+
+_encodings = [
+    ('%','%p'), # this one MUST be first for encode/decode to work properly
+    ('/','%f'),
+    ('\\','%b'),
+    (':','%c'),
+    ('*','%a'),
+    ('?','%q'),
+    ('"','%r'),
+    ('<','%l'),
+    ('>','%g'),
+    ('|','%v')
+]
+
+def filename_encode(name):
+    """Encode special characters to produce a name that can be used as a filename"""
+    for char, code in _encodings:
+        name = name.replace(char, code)
+    return name
+
+def filename_decode(name):
+    """Decode a string that has been encoded using filename_encode"""
+    for char, code in _encodings[1:] + _encodings[0:1]:
+        name = name.replace(code, char)
+    return name
+
+def filedir(datadir, path):
+    return os.path.join(datadir, *[filename_encode(d) + '.dir' for d in path[1:]])
+
+
+## time formatting
+
+TIME_FORMAT = '%Y-%m-%d, %H:%M:%S'
+
+def time_to_str(t):
+    return t.strftime(TIME_FORMAT)
+
+def time_from_str(s):
+    return datetime.strptime(s, TIME_FORMAT)
+
+
+## variable parsing
+
+_re_label = re.compile(r'^([^\[(]*)') # matches up to the first [ or (
+_re_legend = re.compile(r'\((.*)\)') # matches anything inside ( )
+_re_units = re.compile(r'\[(.*)\]') # matches anything inside [ ]
+
+def _get_match(pat, s, default=None):
+    matches = re.findall(pat, s)
+    if len(matches) == 0:
+        if default is None:
+            raise Exception("Cannot parse '{0}'.".format(s))
+        return default
+    return matches[0].strip()
+
+def parse_independent(s):
+    label = _get_match(_re_label, s)
+    units = _get_match(_re_units, s, '')
+    return label, units
+
+def parse_dependent(s):
+    label = _get_match(_re_label, s)
+    legend = _get_match(_re_legend, s, '')
+    units = _get_match(_re_units, s, '')
+    return label, legend, units
+
+
+class SessionStore(object):
+    def __init__(self, datadir, hub):
+        self._sessions = weakref.WeakValueDictionary()
+        self.datadir = datadir
+        self.hub = hub
+
+    def get_all(self):
+        return self._sessions.values()
+
+    def exists(self, path):
+        """Check whether a session exists on disk for a given path.
+
+        This does not tell us whether a session object has been
+        created for that path.
+        """
+        return os.path.exists(filedir(self.datadir, path))
+
+    def get(self, path):
+        """Get a Session object.
+
+        If a session already exists for the given path, return it.
+        Otherwise, create a new session instance.
+        """
+        path = tuple(path)
+        if path in self._sessions:
+            return self._sessions[path]
+        session = Session(self.datadir, path, self.hub)
+        self._sessions[path] = session
+        return session
+
+
+class Session(object):
+    """Stores information about a directory on disk.
+
+    One session object is created for each data directory accessed.
+    The session object manages reading from and writing to the config
+    file, and manages the datasets in this directory.
+    """
+
+    def __init__(self, datadir, path, hub):
+        """Initialization that happens once when session object is created."""
+        self.path = path
+        self.hub = hub
+        self.dir = filedir(datadir, path)
+        self.infofile = os.path.join(self.dir, 'session.ini')
+        self.datasets = weakref.WeakValueDictionary()
+
+        if not os.path.exists(self.dir):
+            os.makedirs(self.dir)
+
+            # notify listeners about this new directory
+            parent_session = Session(datadir, path[:-1], hub)
+            hub.onNewDir(path[-1], parent_session.listeners)
+
+        if os.path.exists(self.infofile):
+            self.load()
+        else:
+            self.counter = 1
+            self.created = self.modified = datetime.now()
+            self.session_tags = {}
+            self.dataset_tags = {}
+
+        self.access() # update current access time and save
+        self.listeners = set()
+
+    def load(self):
+        """Load info from the session.ini file."""
+        S = util.DVSafeConfigParser()
+        S.read(self.infofile)
+
+        sec = 'File System'
+        self.counter = S.getint(sec, 'Counter')
+
+        sec = 'Information'
+        self.created = time_from_str(S.get(sec, 'Created'))
+        self.accessed = time_from_str(S.get(sec, 'Accessed'))
+        self.modified = time_from_str(S.get(sec, 'Modified'))
+
+        # get tags if they're there
+        if S.has_section('Tags'):
+            self.session_tags = eval(S.get('Tags', 'sessions', raw=True))
+            self.dataset_tags = eval(S.get('Tags', 'datasets', raw=True))
+        else:
+            self.session_tags = {}
+            self.dataset_tags = {}
+
+    def save(self):
+        """Save info to the session.ini file."""
+        S = util.DVSafeConfigParser()
+
+        sec = 'File System'
+        S.add_section(sec)
+        S.set(sec, 'Counter', repr(self.counter))
+
+        sec = 'Information'
+        S.add_section(sec)
+        S.set(sec, 'Created',  time_to_str(self.created))
+        S.set(sec, 'Accessed', time_to_str(self.accessed))
+        S.set(sec, 'Modified', time_to_str(self.modified))
+
+        sec = 'Tags'
+        S.add_section(sec)
+        S.set(sec, 'sessions', repr(self.session_tags))
+        S.set(sec, 'datasets', repr(self.dataset_tags))
+
+        with open(self.infofile, 'w') as f:
+            S.write(f)
+
+    def access(self):
+        """Update last access time and save."""
+        self.accessed = datetime.now()
+        self.save()
+
+    def listContents(self, tagFilters):
+        """Get a list of directory names in this directory."""
+        files = os.listdir(self.dir)
+        files.sort()
+        dirs = [filename_decode(s[:-4]) for s in files if s.endswith('.dir')]
+        datasets = [filename_decode(s[:-4]) for s in files if s.endswith('.csv') or s.endswith('.bin')]
+        # apply tag filters
+        def include(entries, tag, tags):
+            """Include only entries that have the specified tag."""
+            return [e for e in entries
+                    if e in tags and tag in tags[e]]
+        def exclude(entries, tag, tags):
+            """Exclude all entries that have the specified tag."""
+            return [e for e in entries
+                    if e not in tags or tag not in tags[e]]
+        for tag in tagFilters:
+            if tag[:1] == '-':
+                filter = exclude
+                tag = tag[1:]
+            else:
+                filter = include
+            #print filter.__name__ + ':', tag
+            #print 'before:', dirs, datasets
+            dirs = filter(dirs, tag, self.session_tags)
+            datasets = filter(datasets, tag, self.dataset_tags)
+            #print 'after:', dirs, datasets
+        return dirs, datasets
+
+    def listDatasets(self):
+        """Get a list of dataset names in this directory."""
+        files = os.listdir(self.dir)
+        files.sort()
+        return [filename_decode(s[:-4]) for s in files if s.endswith('.csv') or s.endswith('.bin')]
+
+    def newDataset(self, title, independents, dependents):
+        num = self.counter
+        self.counter += 1
+        self.modified = datetime.now()
+
+        name = '%05d - %s' % (num, title)
+        dataset = Dataset(self, name, title, create=True, independents=independents, dependents=dependents)
+        self.datasets[name] = dataset
+        self.access()
+
+        # notify listeners about the new dataset
+        self.hub.onNewDataset(name, self.listeners)
+        return dataset
+
+    def openDataset(self, name):
+        # first lookup by number if necessary
+        if isinstance(name, (int, long)):
+            for oldName in self.listDatasets():
+                num = int(oldName[:5])
+                if name == num:
+                    name = oldName
+                    break
+        # if it's still a number, we didn't find the set
+        if isinstance(name, (int, long)):
+            raise errors.DatasetNotFoundError(name)
+
+        filename = filename_encode(name)
+        file_base = os.path.join(self.dir, filename)
+        if not (os.path.exists(file_base + '.csv') or os.path.exists(file_base + '.bin')):
+            raise errors.DatasetNotFoundError(name)
+
+        if name in self.datasets:
+            dataset = self.datasets[name]
+            dataset.access()
+        else:
+            # need to create a new wrapper for this dataset
+            dataset = Dataset(self, name)
+            self.datasets[name] = dataset
+        self.access()
+
+        return dataset
+
+    def updateTags(self, tags, sessions, datasets):
+        def updateTagDict(tags, entries, d):
+            updates = []
+            for entry in entries:
+                changed = False
+                if entry not in d:
+                    d[entry] = set()
+                entryTags = d[entry]
+                for tag in tags:
+                    if tag[:1] == '-':
+                        # remove this tag
+                        tag = tag[1:]
+                        if tag in entryTags:
+                            entryTags.remove(tag)
+                            changed = True
+                    elif tag[:1] == '^':
+                        # toggle this tag
+                        tag = tag[1:]
+                        if tag in entryTags:
+                            entryTags.remove(tag)
+                        else:
+                            entryTags.add(tag)
+                        changed = True
+                    else:
+                        # add this tag
+                        if tag not in entryTags:
+                            entryTags.add(tag)
+                            changed = True
+                if changed:
+                    updates.append((entry, sorted(entryTags)))
+            return updates
+
+        sessUpdates = updateTagDict(tags, sessions, self.session_tags)
+        dataUpdates = updateTagDict(tags, datasets, self.dataset_tags)
+
+        self.access()
+        if len(sessUpdates) + len(dataUpdates):
+            # fire a message about the new tags
+            msg = (sessUpdates, dataUpdates)
+            self.hub.onTagsUpdated(msg, self.listeners)
+
+    def getTags(self, sessions, datasets):
+        sessTags = [(s, sorted(self.session_tags.get(s, []))) for s in sessions]
+        dataTags = [(d, sorted(self.dataset_tags.get(d, []))) for d in datasets]
+        return sessTags, dataTags
+
+class Dataset(object):
+    def __init__(self, session, name, title=None, num=None, create=False, independents=[], dependents=[]):
+        self.hub = session.hub
+        self.name = name
+        file_base = os.path.join(session.dir, filename_encode(name))
+        self.infofile = file_base + '.ini'
+        self.listeners = set() # contexts that want to hear about added data
+        self.param_listeners = set()
+        self.comment_listeners = set()
+
+        if create:
+            self.title = title
+            self.created = self.accessed = self.modified = datetime.now()
+            self.independents = [self.makeIndependent(i) for i in independents]
+            self.dependents = [self.makeDependent(d) for d in dependents]
+            self.parameters = []
+            self.comments = []
+            self.save()
+        else:
+            self.load()
+            self.access()
+
+        self.data = backend.create_backend(file_base, cols=len(self.independents) + len(self.dependents))
+
+    def load(self):
+        S = util.DVSafeConfigParser()
+        S.read(self.infofile)
+
+        gen = 'General'
+        self.title = S.get(gen, 'Title', raw=True)
+        self.created = time_from_str(S.get(gen, 'Created'))
+        self.accessed = time_from_str(S.get(gen, 'Accessed'))
+        self.modified = time_from_str(S.get(gen, 'Modified'))
+
+        def getInd(i):
+            sec = 'Independent %d' % (i+1)
+            label = S.get(sec, 'Label', raw=True)
+            units = S.get(sec, 'Units', raw=True)
+            return dict(label=label, units=units)
+        count = S.getint(gen, 'Independent')
+        self.independents = [getInd(i) for i in range(count)]
+
+        def getDep(i):
+            sec = 'Dependent %d' % (i+1)
+            label = S.get(sec, 'Label', raw=True)
+            units = S.get(sec, 'Units', raw=True)
+            categ = S.get(sec, 'Category', raw=True)
+            return dict(label=label, units=units, category=categ)
+        count = S.getint(gen, 'Dependent')
+        self.dependents = [getDep(i) for i in range(count)]
+
+        def getPar(i):
+            sec = 'Parameter %d' % (i+1)
+            label = S.get(sec, 'Label', raw=True)
+            # TODO: big security hole! eval can execute arbitrary code
+            data = T.evalLRData(S.get(sec, 'Data', raw=True))
+            return dict(label=label, data=data)
+        count = S.getint(gen, 'Parameters')
+        self.parameters = [getPar(i) for i in range(count)]
+
+        # get comments if they're there
+        if S.has_section('Comments'):
+            def getComment(i):
+                sec = 'Comments'
+                time, user, comment = eval(S.get(sec, 'c%d' % i, raw=True))
+                return time_from_str(time), user, comment
+            count = S.getint(gen, 'Comments')
+            self.comments = [getComment(i) for i in range(count)]
+        else:
+            self.comments = []
+
+    def save(self):
+        S = util.DVSafeConfigParser()
+
+        sec = 'General'
+        S.add_section(sec)
+        S.set(sec, 'Created',  time_to_str(self.created))
+        S.set(sec, 'Accessed', time_to_str(self.accessed))
+        S.set(sec, 'Modified', time_to_str(self.modified))
+        S.set(sec, 'Title',       self.title)
+        S.set(sec, 'Independent', repr(len(self.independents)))
+        S.set(sec, 'Dependent',   repr(len(self.dependents)))
+        S.set(sec, 'Parameters',  repr(len(self.parameters)))
+        S.set(sec, 'Comments',    repr(len(self.comments)))
+
+        for i, ind in enumerate(self.independents):
+            sec = 'Independent %d' % (i+1)
+            S.add_section(sec)
+            S.set(sec, 'Label', ind['label'])
+            S.set(sec, 'Units', ind['units'])
+
+        for i, dep in enumerate(self.dependents):
+            sec = 'Dependent %d' % (i+1)
+            S.add_section(sec)
+            S.set(sec, 'Label',    dep['label'])
+            S.set(sec, 'Units',    dep['units'])
+            S.set(sec, 'Category', dep['category'])
+
+        for i, par in enumerate(self.parameters):
+            sec = 'Parameter %d' % (i+1)
+            S.add_section(sec)
+            S.set(sec, 'Label', par['label'])
+            # TODO: smarter saving here, since eval'ing is insecure
+            S.set(sec, 'Data', repr(par['data']))
+
+        sec = 'Comments'
+        S.add_section(sec)
+        for i, (time, user, comment) in enumerate(self.comments):
+            time = time_to_str(time)
+            S.set(sec, 'c%d' % i, repr((time, user, comment)))
+
+        with open(self.infofile, 'w') as f:
+            S.write(f)
+
+    def access(self):
+        """Update time of last access for this dataset."""
+        self.accessed = datetime.now()
+        self.save()
+
+    def makeIndependent(self, label):
+        """Add an independent variable to this dataset."""
+        if isinstance(label, tuple):
+            label, units = label
+        else:
+            label, units = parse_independent(label)
+        return dict(label=label, units=units)
+
+    def makeDependent(self, label):
+        """Add a dependent variable to this dataset."""
+        if isinstance(label, tuple):
+            label, legend, units = label
+        else:
+            label, legend, units = parse_dependent(label)
+        return dict(category=label, label=legend, units=units)
+
+    def addParameter(self, name, data, saveNow=True):
+        self._addParam(name, data)
+        if saveNow:
+            self.save()
+
+        # notify all listening contexts
+        self.hub.onNewParameter(None, self.param_listeners)
+        self.param_listeners = set()
+        return name
+
+    def addParameters(self, params, saveNow=True):
+        for name, data in params:
+            self._addParam(name, data)
+        if saveNow:
+            self.save()
+
+        # notify all listening contexts
+        self.hub.onNewParameter(None, self.param_listeners)
+        self.param_listeners = set()
+
+    def _addParam(self, name, data):
+        for p in self.parameters:
+            if p['label'] == name:
+                raise errors.ParameterInUseError(name)
+        d = dict(label=name, data=data)
+        self.parameters.append(d)
+
+    def getParameter(self, name, case_sensitive=True):
+        for p in self.parameters:
+            if case_sensitive:
+                if p['label'] == name:
+                    return p['data']
+            else:
+                if p['label'].lower() == name.lower():
+                    return p['data']
+        raise errors.BadParameterError(name)
+
+    def addData(self, data):
+        # append the data to the file
+        self.data.addData(data)
+
+        # notify all listening contexts
+        self.hub.onDataAvailable(None, self.listeners)
+        self.listeners = set()
+
+    def getData(self, limit, start):
+        return self.data.getData(limit, start)
+
+    def keepStreaming(self, context, pos):
+        # keepStreaming does something a bit odd and has a confusing name (ERJ)
+        #
+        # The goal is this: a client that is listening for "new data" events should only
+        # receive a single notification even if there are multiple writes.  To do this,
+        # we do the following:
+        #
+        # If a client reads to the end of the dataset, it is added to the list to be notified
+        # if another context does 'addData'.
+        #
+        # if a client calls 'addData', all listeners are notified, and then the set of listeners
+        # is cleared.
+        # 
+        # If a client reads, but not to the end of the dataset, it is immediately notified that
+        # there is more data for it to read, and then removed from the set of notifiers.
+        if self.data.hasMore(pos):
+            if context in self.listeners:
+                self.listeners.remove(context)
+            self.hub.onDataAvailable(None, [context])
+        else:
+            self.listeners.add(context)
+
+    def addComment(self, user, comment):
+        self.comments.append((datetime.now(), user, comment))
+        self.save()
+
+        # notify all listening contexts
+        self.hub.onCommentsAvailable(None, self.comment_listeners)
+        self.comment_listeners = set()
+
+    def getComments(self, limit, start):
+        if limit is None:
+            comments = self.comments[start:]
+        else:
+            comments = self.comments[start:start+limit]
+        return comments, start + len(comments)
+
+    def keepStreamingComments(self, context, pos):
+        if pos < len(self.comments):
+            if context in self.comment_listeners:
+                self.comment_listeners.remove(context)
+            self.hub.onCommentsAvailable(None, [context])
+        else:
+            self.comment_listeners.add(context)
+

--- a/datavault/__init__.py
+++ b/datavault/__init__.py
@@ -1,3 +1,4 @@
+import base64
 from datetime import datetime
 import os
 import re
@@ -74,6 +75,11 @@ def parse_dependent(s):
     legend = _get_match(_re_legend, s, '')
     units = _get_match(_re_units, s, '')
     return label, legend, units
+
+
+## data-url support for storing parameters
+
+DATA_URL_PREFIX = 'data:application/labrad;base64,'
 
 
 class SessionStore(object):
@@ -365,8 +371,15 @@ class Dataset(object):
         def getPar(i):
             sec = 'Parameter %d' % (i+1)
             label = S.get(sec, 'Label', raw=True)
-            # TODO: big security hole! eval can execute arbitrary code
-            data = T.evalLRData(S.get(sec, 'Data', raw=True))
+            raw = S.get(sec, 'Data', raw=True)
+            if raw.startswith(DATA_URL_PREFIX):
+                # decode parameter data from dataurl
+                all_bytes = base64.urlsafe_b64decode(raw[len(DATA_URL_PREFIX):])
+                t, data_bytes = T.unflatten(all_bytes, 'ss')
+                data = T.unflatten(data_bytes, t)
+            else:
+                # old parameters may have been saved using repr
+                data = T.evalLRData(raw)
             return dict(label=label, data=data)
         count = S.getint(gen, 'Parameters')
         self.parameters = [getPar(i) for i in range(count)]
@@ -413,8 +426,11 @@ class Dataset(object):
             sec = 'Parameter %d' % (i+1)
             S.add_section(sec)
             S.set(sec, 'Label', par['label'])
-            # TODO: smarter saving here, since eval'ing is insecure
-            S.set(sec, 'Data', repr(par['data']))
+            # encode the parameter value as a data-url
+            data_bytes, t = T.flatten(par['data'])
+            all_bytes, _ = T.flatten((str(t), data_bytes), 'ss')
+            data_url = DATA_URL_PREFIX + base64.urlsafe_b64encode(all_bytes)
+            S.set(sec, 'Data', data_url)
 
         sec = 'Comments'
         S.add_section(sec)

--- a/datavault/backend.py
+++ b/datavault/backend.py
@@ -1,0 +1,302 @@
+import mmap
+import os
+
+from twisted.internet import reactor
+
+try:
+    import numpy as np
+    use_numpy = True
+except ImportError, e:
+    print e
+    print "Numpy not imported.  The DataVault will operate, but will be slower."
+    use_numpy = False
+
+from .errors import BadDataError
+
+PRECISION = 12 # digits of precision to use when saving data
+DATA_FORMAT = '%%.%dG' % PRECISION
+FILE_TIMEOUT = 60 # how long to keep datafiles open if not accessed
+DATA_TIMEOUT = 300 # how long to keep data in memory if not accessed
+
+class SelfClosingFile(object):
+    """
+    A container for a file object that closes the underlying file handle if not
+    accessed within a specified timeout. Call this container to get the file handle.
+    """
+    def __init__(self, filename, mode, timeout=FILE_TIMEOUT, touch=True):
+        self.filename = filename
+        self.mode = mode
+        self.timeout = timeout
+        self.callbacks = []
+        if touch:
+            self.__call__()
+
+    def __call__(self):
+        if not hasattr(self, '_file'):
+            self._file = open(self.filename, self.mode)
+            self._fileTimeoutCall = reactor.callLater(self.timeout, self._fileTimeout)
+        else:
+            self._fileTimeoutCall.reset(self.timeout)
+        return self._file
+
+    def _fileTimeout(self):
+        for callback in self.callbacks:
+            callback(self)
+        self._file.close()
+        del self._file
+        del self._fileTimeoutCall
+
+    def size(self):
+        return os.fstat(self().fileno()).st_size
+
+    def onClose(self, callback):
+        self.callbacks.append(callback)
+
+class CsvListData(object):
+    """
+    Data backed by a csv-formatted file.
+
+    Stores the entire contents of the file in memory as a list or numpy array
+    """
+
+    def __init__(self, filename, cols, file_timeout=FILE_TIMEOUT, data_timeout=DATA_TIMEOUT):
+        self.filename = filename
+        self._file = SelfClosingFile(filename, 'a+', timeout=file_timeout)
+        self.cols = cols
+        self.timeout = data_timeout
+
+    @property
+    def file(self):
+        return self._file()
+
+    @property
+    def data(self):
+        """Read data from file on demand.
+
+        The data is scheduled to be cleared from memory unless accessed."""
+        if not hasattr(self, '_data'):
+            self._data = []
+            self._datapos = 0
+            self._timeout_call = reactor.callLater(self.timeout, self._on_timeout)
+        else:
+            self._timeout_call.reset(DATA_TIMEOUT)
+        f = self.file
+        f.seek(self._datapos)
+        lines = f.readlines()
+        self._data.extend([float(n) for n in line.split(',')] for line in lines)
+        self._datapos = f.tell()
+        return self._data
+
+    def _on_timeout(self):
+        del self._data
+        del self._datapos
+        del self._timeout_call
+
+    def _saveData(self, data):
+        f = self.file
+        for row in data:
+            # always save with dos linebreaks
+            f.write(', '.join(DATA_FORMAT % v for v in row) + '\r\n')
+        f.flush()
+
+    def addData(self, data):
+        if not len(data) or not isinstance(data[0], list):
+            data = [data]
+        if len(data[0]) != self.cols:
+            raise BadDataError(self.cols, len(data[0]))
+
+        # append the data to the file
+        self._saveData(data)
+
+    def getData(self, limit, start):
+        if limit is None:
+            data = self.data[start:]
+        else:
+            data = self.data[start:start+limit]
+        return data, start + len(data)
+
+    def hasMore(self, pos):
+        return pos < len(self.data)
+
+class CsvNumpyData(CsvListData):
+    """
+    Data backed by a csv-formatted file.
+
+    Stores the entire contents of the file in memory as a list or numpy array
+    """
+
+    def __init__(self, filename, cols):
+        self.filename = filename
+        self._file = SelfClosingFile(filename, 'rw')
+        self.cols = cols
+
+    @property
+    def file(self):
+        return self._file()
+
+    def _get_data(self):
+        """Read data from file on demand.
+
+        The data is scheduled to be cleared from memory unless accessed."""
+        if not hasattr(self, '_data'):
+            try:
+                # if the file is empty, this line can barf in certain versions
+                # of numpy.  Clearly, if the file does not exist on disk, this
+                # will be the case.  Even if the file exists on disk, we must
+                # check its size
+                if self._file.size() > 0:
+                    self._data = np.loadtxt(self.file, delimiter=',')
+                else:
+                    self._data = np.array([[]])
+                if len(self._data.shape) == 1:
+                    self._data.shape = (1, len(self._data))
+            except ValueError:
+                # no data saved yet
+                # this error is raised by numpy <=1.2
+                self._data = np.array([[]])
+            except IOError:
+                # no data saved yet
+                # this error is raised by numpy 1.3
+                self.file.seek(0)
+                self._data = np.array([[]])
+            self._timeout_call = reactor.callLater(DATA_TIMEOUT, self._on_timeout)
+        else:
+            self._timeout_call.reset(DATA_TIMEOUT)
+        return self._data
+
+    def _set_data(self, data):
+        self._data = data
+
+    data = property(_get_data, _set_data)
+
+    def _on_timeout(self):
+        del self._data
+        del self._timeout_call
+
+    def _saveData(self, data):
+        f = self.file
+        # always save with dos linebreaks (requires numpy 1.5.0 or greater)
+        np.savetxt(f, data, fmt=DATA_FORMAT, delimiter=',', newline='\r\n')
+        f.flush()
+
+    def addData(self, data):
+        data = np.asarray(data)
+
+        # reshape single row
+        if len(data.shape) == 1:
+            data.shape = (1, data.size)
+
+        # check row length
+        if data.shape[-1] != self.cols:
+            raise BadDataError(self.cols, data.shape[-1])
+
+        # append data to in-memory data
+        if self.data.size > 0:
+            self.data = np.vstack((self.data, data))
+        else:
+            self.data = data
+
+        # append data to file
+        self._saveData(data)
+
+    def getData(self, limit, start):
+        if limit is None:
+            data = self.data[start:]
+        else:
+            data = self.data[start:start+limit]
+        # nrows should be zero for an empty row
+        nrows = len(data) if data.size > 0 else 0
+        return data, start + nrows
+
+    def hasMore(self, pos):
+        # cheesy hack: if pos == 0, we only need to check whether
+        # the filesize is nonzero
+        if pos == 0:
+            return os.path.getsize(self.filename) > 0
+        else:
+            nrows = len(self.data) if self.data.size > 0 else 0
+            return pos < nrows
+
+class BinaryData(object):
+    """
+    Data backed by a binary-formatted file.
+
+    The file is memory-mapped to take advantage of os-level memory paging.
+    """
+
+    def __init__(self, filename, cols):
+        self._file = SelfClosingFile(filename, 'a+b')
+        self._file.onClose(self._close_map)
+        self.cols = cols
+        self.rowBytes = cols * 8
+
+    @property
+    def file(self):
+        return self._file()
+
+    @property
+    def data(self):
+        if not hasattr(self, '_mmap'):
+            f = self.file
+            self._mmap = mmap.mmap(f.fileno(), self._file.size())
+        return self._mmap
+
+    def _close_map(self, *args):
+        if hasattr(self, '_mmap'):
+            self._mmap.close()
+            del self._mmap
+
+    def addData(self, data):
+        data = np.asarray(data, dtype='>f8')
+
+        # reshape single row
+        if len(data.shape) == 1:
+            data.shape = (1, data.size)
+
+        # check row length
+        if data.shape[-1] != self.cols:
+            raise BadDataError(self.cols, data.shape[-1])
+
+        # append data to memory map
+        bs = data.tostring('C')
+        f = self.file
+        f.seek(self._file.size())
+        f.write(bs)
+        f.flush()
+        self._close_map() # close the mmap since we can't resize. TODO: check whether we can mremap
+
+    def getData(self, limit, start):
+        size = self._file.size()
+        if size == 0:
+            return [], 0
+        startOfs = start * self.rowBytes
+        if limit is None:
+            bs = self.data[startOfs:]
+        else:
+            endOfs = startOfs + limit * self.rowBytes
+            bs = self.data[startOfs:endOfs]
+        data = np.reshape(np.fromstring(bs, dtype='>f8'), [-1, self.cols])
+        # nrows should be zero for an empty row
+        nrows = len(data) if data.size > 0 else 0
+        return data, start + nrows
+
+    def hasMore(self, pos):
+        nrows = self._file.size() / self.rowBytes
+        return pos < nrows
+
+def create_backend(filename, cols):
+    """Make a data object that manages in-memory and on-disk storage for a dataset.
+
+    filename should be specified without a file extension. If there is an existing
+    file in csv or binary format, we create a backend of the appropriate type. If
+    no file exists, we create a new backend to store data in binary form.
+    """
+    csv_file = filename + '.csv'
+    bin_file = filename + '.bin'
+    if os.path.exists(csv_file):
+        if use_numpy:
+            return CsvNumpyData(csv_file, cols)
+        else:
+            return CsvListData(csv_file, cols)
+    else:
+        return BinaryData(bin_file, cols)

--- a/datavault/errors.py
+++ b/datavault/errors.py
@@ -1,0 +1,43 @@
+from labrad import types as T
+
+class NoDatasetError(T.Error):
+    """Please open a dataset first."""
+    code = 2
+
+class DatasetNotFoundError(T.Error):
+    code = 3
+    def __init__(self, name):
+        self.msg = "Dataset '{0}' not found!".format(name)
+
+class DirectoryExistsError(T.Error):
+    code = 4
+    def __init__(self, name):
+        self.msg = "Directory '{0}' already exists!".format(name)
+
+class DirectoryNotFoundError(T.Error):
+    code = 5
+
+class EmptyNameError(T.Error):
+    """Names of directories or keys cannot be empty"""
+    code = 6
+    def __init__(self, path):
+        self.msg = "Directory {0} does not exist!".format(path)
+
+class ReadOnlyError(T.Error):
+    """Points can only be added to datasets created with 'new'."""
+    code = 7
+
+class BadDataError(T.Error):
+    code = 8
+    def __init__(self, varcount, gotcount):
+        self.msg = "Dataset requires {0} values per datapoint not {1}.".format(varcount, gotcount)
+
+class BadParameterError(T.Error):
+    code = 9
+    def __init__(self, name):
+        self.msg = "Parameter '{0}' not found.".format(name)
+
+class ParameterInUseError(T.Error):
+    code = 10
+    def __init__(self, name):
+        self.msg = "Already a parameter called '{0}'.".format(name)

--- a/datavault/util.py
+++ b/datavault/util.py
@@ -1,0 +1,25 @@
+import ConfigParser as cp
+
+class DVSafeConfigParser(cp.SafeConfigParser):
+    """.ini-style config parser with improved handling of line-endings.
+
+    By default, SafeConfigParser uses the platform-default line ending, and
+    does not allow specifying anything different. This version allows the
+    line ending to be specified so that config files can be handled consistently
+    across OSes.
+    """
+
+    def write(self, fp, newline='\r\n'):
+        """Write an .ini-format representation of the configuration state."""
+        if self._defaults:
+            fp.write("[%s]" % cp.DEFAULTSECT + newline)
+            for (key, value) in self._defaults.items():
+                fp.write(("%s = %s" + newline) % (key, str(value).replace('\n', '\n\t')))
+            fp.write(newline)
+        for section in self._sections:
+            fp.write("[%s]" % section + newline)
+            for (key, value) in self._sections[section].items():
+                if key != "__name__":
+                    fp.write(("%s = %s" + newline) %
+                             (key, str(value).replace('\n', '\n\t')))
+            fp.write(newline)

--- a/tests/config_datavault.py
+++ b/tests/config_datavault.py
@@ -1,0 +1,23 @@
+import os
+import sys
+
+import labrad
+import labrad.util
+
+def main(args):
+    """Configure the data directory for the local labrad node."""
+    directory = os.path.abspath(args[1])
+
+    node = labrad.util.getNodeName()
+
+    print "Configuring data vault repository for node '{}' to {}".format(node, directory)
+    assert os.path.exists(directory)
+    assert os.path.isdir(directory)
+
+    with labrad.connect() as cxn:
+        reg = cxn.registry()
+        reg.cd(['', 'Servers', 'Data Vault', 'Repository'], True)
+        reg.set(node, directory)
+
+if __name__ == '__main__':
+    main(sys.argv)

--- a/tests/test_datavault.py
+++ b/tests/test_datavault.py
@@ -1,0 +1,80 @@
+from datetime import datetime
+
+import numpy as np
+import pytest
+
+import labrad
+
+# use the same path for all datasets in a given run of the tests in this module
+_path = None
+
+def _test_path():
+    """Path where we'll put test datasets in the data vault"""
+    global _path
+    if _path is None:
+        _path = ['test', datetime.utcnow().strftime('%Y%m%d')]
+    return _path
+
+def setup_dv(cxn):
+    dv = cxn.data_vault
+    dv.cd(_test_path())
+    return dv
+
+@pytest.yield_fixture
+def dv():
+    with labrad.connect() as cxn:
+        dv = setup_dv(cxn)
+        yield dv
+
+def test_create_dataset(dv):
+    """Create a simple dataset, add some data and read it back"""
+    _path, _name = dv.new('test', ['x', 'y'], ['z'])
+
+    data = []
+    for x in xrange(10):
+        for y in xrange(10):
+            data.append([x/10., y/10., x*y])
+
+    for row in data:
+        dv.add(row)
+
+    stored = dv.get()
+    assert np.equal(data, stored).all()
+
+def test_read_dataset():
+    """Create a simple dataset and read it back while still open and after closed"""
+    data = []
+    for x in xrange(10):
+        for y in xrange(10):
+            data.append([x/10., y/10., x*y])
+
+    with labrad.connect() as cxn:
+        dv = setup_dv(cxn)
+
+        path, name = dv.new('test', ['x', 'y'], ['z'])
+
+        for row in data:
+            dv.add(row)
+
+        # read in new connection while the dataset is still open
+        with labrad.connect() as cxn2:
+            dv2 = cxn2.data_vault
+            dv2.cd(path)
+            dv2.open(name)
+            stored = dv2.get()
+            assert np.equal(data, stored).all()
+
+            # add more data and ensure that we get it
+            dv.add([1, 1, 100])
+
+            row = dv2.get()
+            assert np.equal(row, [1, 1, 100]).all()
+
+    # read in new connection after dataset has been closed
+    with labrad.connect() as cxn:
+        dv = cxn.data_vault
+        dv.cd(path)
+        dv.open(name)
+        stored = dv.get(len(data)) # get only up to the last extra row
+        assert np.equal(data, stored).all()
+

--- a/tests/test_datavault.py
+++ b/tests/test_datavault.py
@@ -4,6 +4,8 @@ import numpy as np
 import pytest
 
 import labrad
+import labrad.types as T
+import labrad.util.hydrant as hydrant
 
 # use the same path for all datasets in a given run of the tests in this module
 _path = None
@@ -77,6 +79,21 @@ def test_read_dataset():
         dv.open(name)
         stored = dv.get(len(data)) # get only up to the last extra row
         assert np.equal(data, stored).all()
+
+
+def test_parameters(dv):
+    """Create a dataset with parameters"""
+    dv.new('test', ['x', 'y'], ['z'])
+    for i in xrange(100):
+        t = hydrant.randType(noneOkay=False)
+        a = hydrant.randValue(t)
+        name = 'param{}'.format(i)
+        dv.add_parameter(name, a)
+        b = dv.get_parameter(name)
+        sa, ta = T.flatten(a)
+        sb, tb = T.flatten(b)
+        assert ta == tb
+        assert sa == sb
 
 if __name__ == "__main__":
     pytest.main(['-v', __file__])

--- a/tests/test_datavault.py
+++ b/tests/test_datavault.py
@@ -17,7 +17,7 @@ def _test_path():
 
 def setup_dv(cxn):
     dv = cxn.data_vault
-    dv.cd(_test_path())
+    dv.cd(_test_path(), True)
     return dv
 
 @pytest.yield_fixture
@@ -78,3 +78,5 @@ def test_read_dataset():
         stored = dv.get(len(data)) # get only up to the last extra row
         assert np.equal(data, stored).all()
 
+if __name__ == "__main__":
+    pytest.main(['-v', __file__])


### PR DESCRIPTION
We've discussed the possibility of having the data vault store data in binary form, rather than as csv files. This should reduce the file size of typical data sets, and it should also make loading and saving data much faster, because we can avoid the overhead of csv encoding/decoding. I've also used mmap for the in-memory representation of the data, which will use the os-level caching of memory pages, rather than the ad-hoc memory cache we implemented for python lists and numpy arrays using DATA_TIMEOUT. I want to add tests and some performance benchmarks, but wanted to get people's comments on this prototype.