### PR TITLE
Fix dr logger

### DIFF
--- a/GUIs/LabRADPlotWidget3.py
+++ b/GUIs/LabRADPlotWidget3.py
@@ -1,41 +1,59 @@
-import os, sys, time
+import sys
 
-import PyQt4.Qt as Qt
-import PyQt4.QtCore as QtCore
-
-from twisted.internet.defer import inlineCallbacks, returnValue
-
-import numpy as np, matplotlib as mp, matplotlib.pyplot as plt
+from PyQt4 import Qt, QtCore
+from twisted.internet.defer import inlineCallbacks
+import numpy as np
+import matplotlib.pyplot as plt
 from matplotlib.backends.backend_qt4agg import FigureCanvasQTAgg as FigureCanvas
 from matplotlib.backends.backend_qt4agg import NavigationToolbar2QTAgg as NavigationToolbar
 from matplotlib.figure import Figure
 
-UPDATE_PERIOD = 1.0         # (in seconds)
-DR_LOGGER_CHECK_SKIP = 5    # check the DR Logger every X updates
-COLORS = ['red', 'green', 'blue', 'magenta', 'black', 'darkgoldenrod', 'Brown', 'darkslategrey', 'orangered', 'OliveDrab']
+UPDATE_PERIOD = 1.0          # (in seconds)
+DR_LOGGER_CHECK_SKIP = 1     # check the DR Logger every X updates
+TIME_DELAY_WARNING = 10      # display in bold red if last data point older than X seconds
+COLORS = ['red', 'green', 'blue', 'magenta', 'black', 'darkgoldenrod',
+          'Brown', 'darkslategrey', 'orangered', 'OliveDrab']
 plt.rcParams['axes.color_cycle'] = COLORS
-PLOT_BACKGROUND = '#E5E5E5' # HTML colors are allowed
+PLOT_BACKGROUND = '#E5E5E5'  # HTML colors are allowed
 NEW_DATASET_SIGNAL = 99901
 NEW_DATA_SIGNAL = 99902
 
-HISTORY_TOOLTIP = 'For example: \n60 - last 60 data points \n60s - last 60 seconds \n' + \
-                  '60m - last 60 minutes \n60d - last 60 days'
-FILTER_TOOLTIP = "Filter out excess points to make graph more responsive.\n" + \
-                  "This means not all data will be displayed for long histories or small numbers of points."
-                  
-NO_SERVER_STYLE = 'QPushButton {color: red; font-weight: bold;}'
-NO_SERVER_TEXT = 'Not Running!'
-NOT_LOGGING_STYLE = 'QPushButton {color: red; font-weight: bold;}'
-NOT_LOGGING_TEXT = 'Not Logging!'
-LOGGING_STYLE = 'QPushButton {color: green; font-weight: bold;}'
-LOGGING_TEXT = 'Logging'
+HISTORY_TOOLTIP = """For example:
+60 - last 60 data points
+60s - last 60 seconds
+60m - last 60 minutes
+60d - last 60 days"""
 
-# A Qt Widget wrapper with some added functionality for selecting parts of a dataset		
+FILTER_TOOLTIP = """Filter out excess points to make graph more responsive.
+This means not all data will be displayed for long histories or small numbers of points."""
+
+NO_SERVER_STYLE = 'QLabel {color: red; font-weight: bold; font-size: 15pt;}'
+NO_SERVER_TEXT = 'Not Running!'
+NOT_LOGGING_STYLE = NO_SERVER_STYLE
+NOT_LOGGING_TEXT = 'Not Logging!'
+LOGGING_STYLE = '* {color: green; font-weight: bold;}'
+LOGGING_TEXT = 'Logging'
+TIME_LABEL = """Time since last point:
+{time} {unit}"""
+TIME_DELAY_STYLE = 'QLabel {color: darkorange; font-weight: bold; font-size: 15pt;}'
+TIME_UNKNOWN_STYLE = 'QLabel {color: purple; font-weight: bold; font-size: 15pt;}'
+TIME_NORMAL_STYLE = 'QLabel {color: black; font-size: 12pt;}'
+ERROR_TITLE_STYLE = 'QLabel {color: red; font-weight: bold; font-size: 15pt;}'
+
+# noinspection PyAttributeOutsideInit
 class LabRADPlotWidget3(Qt.QWidget):
 
-    def __init__(self, parent, cxn=None, path=[], dataset=None, timer=None, drLoggerName=None):
-        """
-        A Qt widget that plots a labrad dataset, using Matplotlib.
+    def __init__(self, parent, cxn=None, path=None, dataset=None, timer=None, drLoggerName=None):
+        """A Qt widget that plots a labrad dataset, using Matplotlib.
+
+        Intended for use with the DR Logger.
+        :param parent: Parent widget
+        :param cxn: LabRAD connection
+        :param list[str] path: data vault path
+        :param str or int dataset: dataset name or number
+        :param timer: Qt timer to use for updating--timeout signal is used.
+            If None, create our own timer.
+        :param str drLoggerName: name of the DR logger server to monitor
         """
         # run qwidget init
         Qt.QWidget.__init__(self, parent)
@@ -50,12 +68,14 @@ class LabRADPlotWidget3(Qt.QWidget):
         self.tab = Qt.QTabWidget(self)
         self.layout.addWidget(self.tab)
         # labrad variables
-        self.path = path
+        self.path = path if path is not None else []
         self.dataset = dataset
+        self.waitingOnLabrad = False
         # start the labrad connection
         if cxn is None:
             self.ownCxn = True
             import labrad
+            import labrad.util
             try:
                 cxnDef = labrad.connectAsync(name=labrad.util.getNodeName() + ' Plot Widget')
             except AttributeError:
@@ -74,19 +94,20 @@ class LabRADPlotWidget3(Qt.QWidget):
         else:
             self.updateTimer = timer
             self.updateTimer.timeout.connect(self.timerFunc)
-            
+
     def closeEvent(self, event):
         self.destroyPlot()
         self.updateTimer.stop()
         if self.ownCxn:
-            self.cxn.disconnect()           
-        
+            self.cxn.disconnect()
+
     def _makeLine(self):
-        line = Qt.QFrame(self);
-        line.setFrameShape(Qt.QFrame.HLine);
-        line.setFrameShadow(Qt.QFrame.Sunken);
+        line = Qt.QFrame(self)
+        line.setFrameShape(Qt.QFrame.HLine)
+        line.setFrameShadow(Qt.QFrame.Sunken)
         return line
-        
+
+    # noinspection PyAttributeOutsideInit
     def makeOptionsBox(self):
         # checkboxes
         self.optionsLayout.addWidget(Qt.QLabel("<b>Options:</b>"))
@@ -130,47 +151,65 @@ class LabRADPlotWidget3(Qt.QWidget):
         # DR Logger server monitoring
         if self.drLoggerName:
             self.optionsLayout.addWidget(self._makeLine())
-            self.optionsLayout.addWidget(Qt.QLabel("DR Logger is: "))
-            self.drLoggerPB = Qt.QPushButton("Unchecked", self)
-            self.drLoggerPB.clicked.connect(self.drLoggerPBClicked)
-            self.optionsLayout.addWidget(self.drLoggerPB)
+            label = Qt.QLabel("DR Logger")
+            label.setAlignment(QtCore.Qt.AlignHCenter)
+            label.setStyleSheet("* {font-weight: bold; font-size: 14pt}")
+            self.optionsLayout.addWidget(label)
+            self.drLoggerLabel = Qt.QLabel("Unchecked", self)
+            self.drLoggerLabel.setAlignment(QtCore.Qt.AlignHCenter)
+            self.optionsLayout.addWidget(self.drLoggerLabel)
+            self.drLoggerTimeLabel = Qt.QLabel(TIME_LABEL, self)
+            self.drLoggerTimeLabel.setAlignment(QtCore.Qt.AlignHCenter)
+            self.optionsLayout.addWidget(self.drLoggerTimeLabel)
+            self.drLoggerErrorsLayout = Qt.QVBoxLayout()
+            label = Qt.QLabel("Errors")
+            label.setAlignment(QtCore.Qt.AlignHCenter)
+            label.setStyleSheet("* {font-weight: bold; font-size: 12pt}")
+            self.drLoggerErrorsLayout.addWidget(label)
+            label = Qt.QLabel("None")
+            label.setToolTip("Callooh! Callay!")
+            label.setAlignment(QtCore.Qt.AlignHCenter)
+            self.drLoggerErrorsLayout.addWidget(label)
+            self.drLoggerLastHadErrors = False
+            self.optionsLayout.addLayout(self.drLoggerErrorsLayout)
+
         else:
-            self.drLoggerPB = None
+            self.drLoggerLabel = None
         # add stretch to move them all to the top
         self.optionsLayout.addStretch()
-        
+
     def setCxn(self, cxn):
         self.cxn = cxn
         if self.dataset:
             self.loadDataset()
-        self.waitingOnLabrad=False
-        
-    def setDataset(self, path=[], dataset=None):
+        self.waitingOnLabrad = False
+
+    def setDataset(self, path=None, dataset=None):
         if path:
             self.path = path
         if dataset:
             self.dataset = dataset
         self.loadDataset()
-        
+
     def getDataset(self):
         return self.dataset
-        
+
     def loadDataset(self):
         p = self.cxn.data_vault.packet()
         p.cd(self.path)
         p.dir()
         d = p.send()
         d.addCallback(self.loadDatasetCallback)
-        
+
     def loadDatasetCallback(self, response):
         # load up our dataset.
         dsList = response.dir[1]
-        if type(self.dataset) == str and not self.dataset in dsList:
+        if type(self.dataset) == str and self.dataset not in dsList:
             for ds in dsList:
                 if self.dataset in ds:
                     self.dataset = ds
                     break
-            else:   # note this else is for the for loop, not the if statement
+            else:
                 self.dataset = None
                 print "Dataset %s not found!" % self.dataset
         p = self.cxn.data_vault.packet()
@@ -180,8 +219,8 @@ class LabRADPlotWidget3(Qt.QWidget):
         # automatically switch datasets when new one created in our current directory
         dv = self.cxn.data_vault
         dv.signal__new_dataset(NEW_DATASET_SIGNAL)
-        dv.addListener(listener = self.switchDataset, source=None, ID=NEW_DATASET_SIGNAL)
-        
+        dv.addListener(listener=self.switchDataset, source=None, ID=NEW_DATASET_SIGNAL)
+
     def switchDataset(self, msgContext, newDataset):
         # we've received a signal for a new dataset. switch to it.
         print "Switching dataset to: %s" % newDataset
@@ -189,7 +228,7 @@ class LabRADPlotWidget3(Qt.QWidget):
         p = self.cxn.data_vault.packet()
         p.open(self.dataset)
         p.send()
-        
+
     def timerFunc(self):
         if self.waitingOnLabrad:
             return
@@ -206,51 +245,98 @@ class LabRADPlotWidget3(Qt.QWidget):
             if self.drLoggerName not in self.cxn.servers:
                 self.drLoggerCallback(None)
             else:
-                p = self.cxn[self.drLoggerName].packet()
-                p.select_device()
-                p.logging()
-                d = p.send()
-                d.addCallback(self.drLoggerCallback)
+                @inlineCallbacks
+                def do_logging():
+                    try:
+                        p = self.cxn[self.drLoggerName].packet()
+                        p.select_device()
+                        p.logging()
+                        p.current_time()
+                        p.errors()
+                        result = yield p.send()
+                        self.drLoggerCallback(result)
+                    except Exception as e:
+                        self.drLoggerCallback(None, err=e)
+                do_logging()
         self.drLoggerCounter += 1
         self.drLoggerCounter %= DR_LOGGER_CHECK_SKIP
-        
-    def drLoggerCallback(self, response):
-        ''' update the DR Logger monitoring stuff.
-        if response is None, then there was no DR Logger server '''
+
+    def drLoggerCallback(self, response, err=None):
+        """ update the DR Logger monitoring stuff.
+        if response is None, then there was no DR Logger server """
+        # server status
+        self.drLoggerLabel.setToolTip('')
         if response is None:
-            self.drLoggerPB.setStyleSheet(NO_SERVER_STYLE)
-            self.drLoggerPB.setText(NO_SERVER_TEXT)
-        elif not response.logging:
-            self.drLoggerPB.setStyleSheet(NOT_LOGGING_STYLE)
-            self.drLoggerPB.setText(NOT_LOGGING_TEXT)
-        elif response.logging:
-            self.drLoggerPB.setStyleSheet(LOGGING_STYLE)
-            self.drLoggerPB.setText(LOGGING_TEXT)
-    
-    def drLoggerPBClicked(self):
-        if str(self.drLoggerPB.text()) == LOGGING_TEXT:
-            self.drLoggerPB.setText('Nothing to do!')
-        elif str(self.drLoggerPB.text()) == NOT_LOGGING_TEXT:
-            p = self.cxn[self.drLoggerName].packet()
-            p.select_device()
-            p.logging(True)
-            p.send()
-            self.drLoggerPB.setText('Starting...')
-        elif str(self.drLoggerPB.text()) == NO_SERVER_TEXT:
-            # find node
-            for s in self.cxn.servers:
-                if s.lower().startswith('node'):
-                    break
+            self.drLoggerLabel.setStyleSheet(NO_SERVER_STYLE)
+            if err:
+                self.drLoggerLabel.setText("Server Error")
+                response = type('dummy', (object,), {})
+                response.errors = [('DR Logger', str(err))]
             else:
-                self.drLoggerPB.setText('No node found!')
-                return
-            self.cxn[s].start(self.drLoggerName)
-            self.drLoggerPB.setText('Starting...')
-        
+                self.drLoggerLabel.setText(NO_SERVER_TEXT)
+        elif not response.logging:
+            self.drLoggerLabel.setStyleSheet(NOT_LOGGING_STYLE)
+            self.drLoggerLabel.setText(NOT_LOGGING_TEXT)
+        elif response.logging:
+            self.drLoggerLabel.setStyleSheet(LOGGING_STYLE)
+            self.drLoggerLabel.setText(LOGGING_TEXT)
+        # time since last point
+        try:
+            t = round(abs(response.current_time - self.last_data_time), 1)
+            self.drLoggerTimeLabel.setText(TIME_LABEL.format(time=t, unit='s'))
+            if t > TIME_DELAY_WARNING:
+                self.drLoggerTimeLabel.setStyleSheet(TIME_DELAY_STYLE)
+            else:
+                self.drLoggerTimeLabel.setStyleSheet(TIME_NORMAL_STYLE)
+        except (AttributeError, TypeError):
+            self.drLoggerTimeLabel.setText(TIME_LABEL.format(time='unknown', unit=''))
+            self.drLoggerTimeLabel.setStyleSheet(TIME_UNKNOWN_STYLE)
+        if response is None:
+            return
+        # errors
+        if not len(response.errors):
+            # don't bother if we didn't have errors last time
+            if self.drLoggerLastHadErrors:
+                # remove all but first
+                layout_item = self.drLoggerErrorsLayout.takeAt(1)
+                while layout_item:
+                    layout_item.widget().setParent(None)
+                    layout_item = self.drLoggerErrorsLayout.takeAt(1)
+                # add None label
+                label = Qt.QLabel("None")
+                label.setToolTip("O frabjous day!")
+                label.setAlignment(QtCore.Qt.AlignHCenter)
+                self.drLoggerErrorsLayout.addWidget(label)
+                self.drLoggerLastHadErrors = False
+        else:
+            self.drLoggerLastHadErrors = True
+            i = 1
+            layout_item = self.drLoggerErrorsLayout.takeAt(i)
+            err_dict = dict(response.errors)
+            while layout_item:
+                widget = layout_item.widget()
+                if str(widget.text()) in err_dict:
+                    msg = err_dict.pop(str(widget.text()), "No message given.")
+                    if msg != str(widget.toolTip()):
+                        widget.setToolTip(msg)
+                    self.drLoggerErrorsLayout.insertWidget(i, widget)
+                    i += 1
+                else:
+                    layout_item.widget().setParent(None)
+                layout_item = self.drLoggerErrorsLayout.takeAt(i)
+            for title, msg in err_dict.items():
+                label = Qt.QLabel(title)
+                label.setToolTip(msg)
+                label.setAlignment(QtCore.Qt.AlignHCenter)
+                label.setStyleSheet(ERROR_TITLE_STYLE)
+                self.drLoggerErrorsLayout.addWidget(label)
+
     def datavaultCallback(self, response):
         self.newData = response.get
-        if hasattr(self.newData, 'asarray'): # Backwards compatibility
+        if hasattr(self.newData, 'asarray'):  # Backwards compatibility
             self.newData = self.newData.asarray
+        if len(self.newData):
+            self.last_data_time = self.newData[-1, 0]
         if 'variables' in response.settings:
             self.variables = response.variables
             self.xAxisCurrentUnit = self.variables[0][0][1]
@@ -264,7 +350,7 @@ class LabRADPlotWidget3(Qt.QWidget):
             self.plotNewData()
 
     def destroyPlot(self):
-        ''' Delete the current plot. '''
+        """ Delete the current plot. """
         self.tab.clear()
         self.tabs = {}
         self.canvases = {}
@@ -273,14 +359,14 @@ class LabRADPlotWidget3(Qt.QWidget):
         self.linesByLabel = {}
 
     def buildPlot(self):
-        ''' build a new plot. '''
+        """ build a new plot. """
         self.destroyPlot()
         self.dirtyPlots = True
         # parse the variables
-        xlabel = '%s [%s]' % (self.variables[0][0])
+        xlabel = '{0} [{1}]'.format(*self.variables[0][0])
         labels = []
         legends = {}
-        units = {}        
+        units = {}
         for legend, label, unit in self.variables[1]:
             if label not in labels:
                 labels.append(label)
@@ -317,7 +403,7 @@ class LabRADPlotWidget3(Qt.QWidget):
                 ax = self.figures[label].add_subplot(111, axisbg=PLOT_BACKGROUND)
             # the data are stored in self.data
             self.data = self.newData.copy()
-            line = ax.plot(self.data[:,0], self.data[:,i+1], '.-', label=legend)[0]
+            line = ax.plot(self.data[:, 0], self.data[:, i+1], '.-', label=legend)[0]
             self.lines.append(line)
             self.linesByLabel[label].append(line)
             ax.set_xlabel(xlabel, fontsize=19)
@@ -327,7 +413,7 @@ class LabRADPlotWidget3(Qt.QWidget):
         self.rescale()
         self.buildLineButtons()
         self.rebuildPlot = False
-        
+
     def plotNewData(self):
         if self.newData is not None and self.newData.shape[0] != 0:
             # update data
@@ -340,7 +426,7 @@ class LabRADPlotWidget3(Qt.QWidget):
         else:
             label = str(self.tab.tabText(self.tab.currentIndex()))
             xmin, xmax = self.figures[label].axes[0].get_xlim()
-        imin, imax = np.searchsorted(self.data[:,0], [xmin, xmax])
+        imin, imax = np.searchsorted(self.data[:, 0], [xmin, xmax])
         # are we filtering points?
         try:
             if self.filterCB.isChecked():
@@ -354,14 +440,18 @@ class LabRADPlotWidget3(Qt.QWidget):
         else:
             step = 1
         start = imin
-        while start % step != (imax-1)%step:
+        while start % step != (imax-1) % step:
             start += 1
         # now slice out those data points and plot them
         for i, (legend, label, unit) in enumerate(self.variables[1]):
-            self.lines[i].set_xdata(self.data[start::step,0])
-            self.lines[i].set_ydata(self.data[start::step,i+1])
+            # filter out any NaN, inf, etc.
+            x_slice = self.data[start::step, 0]
+            y_slice = self.data[start::step, i+1]
+            valid_inds = np.isfinite(y_slice)
+            self.lines[i].set_xdata(x_slice[valid_inds])
+            self.lines[i].set_ydata(y_slice[valid_inds])
             d = self.data[-1, i+1]
-            if d < 1 and d > 1e-3:
+            if 1 > d > 1e-3:
                 self.lines[i].my_label.setText('{0:.3f}'.format(d))
             else:
                 self.lines[i].my_label.setText('{0:.3g}'.format(d))
@@ -374,21 +464,21 @@ class LabRADPlotWidget3(Qt.QWidget):
         if self.zeroXAxisCB.isChecked():
             if self.xAxisZero is not None:
                 # if we've already done it, just do to new data
-                self.newData[:,0] -= self.xAxisZero
+                self.newData[:, 0] -= self.xAxisZero
             else:
                 # if not, do it to all data
-                self.xAxisZero = self.data[0,0]
-                self.data[:,0] -= self.xAxisZero
-                self.newData[:,0] -= self.xAxisZero
+                self.xAxisZero = self.data[0, 0]
+                self.data[:, 0] -= self.xAxisZero
+                self.newData[:, 0] -= self.xAxisZero
                 self.dirtyPlots = True
         # have we previously zeroed the data and now we undo it?
         elif self.xAxisZero is not None:
-            self.data[:,0] += self.xAxisZero
+            self.data[:, 0] += self.xAxisZero
             self.dirtyPlots = True
             self.xAxisZero = None
-            
+
     def handleUnitConversion(self):
-        ''' Note that we only do unit conversion for the (shared) X-axis. '''
+        """ Note that we only do unit conversion for the (shared) X-axis. """
         import labrad.units as U
         newUnit = str(self.xAxisUnitsLE.text()).strip()
         currentUnit = U.Unit(self.xAxisCurrentUnit)
@@ -399,32 +489,28 @@ class LabRADPlotWidget3(Qt.QWidget):
         if newUnit != self.xAxisCurrentUnit:
             try:
                 conversion = currentUnit.conversionTupleTo(newUnit)
-                self.data[:,0] = (self.data[:,0] + conversion[1]) * conversion[0]
+                self.data[:, 0] = (self.data[:, 0] + conversion[1]) * conversion[0]
                 if self.xAxisZero is not None:
                     self.xAxisZero = (self.xAxisZero + conversion[1])*conversion[0]
                 self.xAxisCurrentUnit = newUnit
                 for figure in self.figures.values():
                     figure.axes[0].set_xlabel('%s [%s]' % (self.variables[0][0][0], self.xAxisCurrentUnit))
                 self.dirtyPlots = True
-            except TypeError as e:
+            except TypeError:
                 pass
         # run new data through conversion
         if self.newData is not None and self.newData.shape[0] > 0:
             conversion = originalUnit.conversionTupleTo(self.xAxisCurrentUnit)
-            self.newData[:,0] = (self.newData[:,0]+conversion[1])*conversion[0]
+            self.newData[:, 0] = (self.newData[:, 0]+conversion[1])*conversion[0]
 
     def rescale(self):
-        ''' scale the plots to show all the data. only use visible lines. account for absolute limits in settings. '''
+        """ scale the plots to show all the data. only use visible lines. account for absolute limits in settings. """
         for figure in self.figures.values():
-            ax = figure.axes[0]            
+            ax = figure.axes[0]
             if self.rescaleXCB.isChecked():
                 xmin, xmax = self.handleHistory()
                 ax.set_xlim(xmin, xmax)
-            else:
-                xmin, xmax = ax.get_xlim()
             if self.rescaleYCB.isChecked():
-                xdata = self.data[:,0]
-                imin, imax = np.searchsorted(xdata, [xmin, xmax])
                 ymax, ymin = None, sys.float_info.max
                 for i, l in enumerate(ax.lines):
                     if not l.get_visible():
@@ -437,12 +523,12 @@ class LabRADPlotWidget3(Qt.QWidget):
         # and redraw
         for canvas in self.canvases.values():
             canvas.draw()
-                
-            
+
+    # noinspection PyUnresolvedReferences
     def handleHistory(self):
         import labrad.units as U
         hist = str(self.historyLE.text()).strip()
-        xdata = self.data[:,0]
+        xdata = self.data[:, 0]
         xunit = self.xAxisCurrentUnit
         xmax = xdata.max()
         try:
@@ -457,35 +543,35 @@ class LabRADPlotWidget3(Qt.QWidget):
             else:
                 xmin = xdata[-int(hist):].min()
             return max(xmin, xdata.min()), xmax
-        except (ValueError, IndexError) as e:
+        except (ValueError, IndexError):
             return xdata.min(), xdata.max()
-            
+
     def buildLineButtons(self):
-        ''' Create a toggle button for each line on each graph.
-            Create a label with the current value underneath. '''
+        """ Create a toggle button for each line on each graph.
+            Create a label with the current value underneath. """
         # the button callback factory
-        def make_callback(button):
-            ''' wrap the callback in another function to keep the variable
-                'button' in the closure. Yay Python!'''
+        def make_callback(closed_button):
+            """ wrap the callback in another function to keep the variable
+                'closed_button' in the closure. Yay Python!"""
             def callback():
-                button._my_line.set_visible(button.isChecked())
-                button._my_canvas.draw()
+                closed_button.my_line.set_visible(closed_button.isChecked())
+                closed_button.my_canvas.draw()
                 self.rescale()
             return callback
-        
+
         for label, lines in self.linesByLabel.items():
             # line them up in a row
             layout = Qt.QHBoxLayout()
             dataLayout = Qt.QHBoxLayout()
             for line in lines:
                 # button
-                button = Qt.QPushButton(unichr(9644) +' '+ line.get_label(), self.tabs[label])
+                button = Qt.QPushButton(unichr(9644) + ' ' + line.get_label(), self.tabs[label])
                 button.setStyleSheet('QPushButton {color: %s; font-weight: bold; font-size: 16px}' % line.get_color())
                 button.setCheckable(True)
                 button.setChecked(line.get_visible())
                 button.setMinimumHeight(50)
-                button._my_line = line
-                button._my_canvas = self.canvases[label]
+                button.my_line = line
+                button.my_canvas = self.canvases[label]
                 button.clicked.connect(make_callback(button))
                 layout.addWidget(button)
                 # label
@@ -493,11 +579,12 @@ class LabRADPlotWidget3(Qt.QWidget):
                 lab.setStyleSheet('QLabel {font-weight: bold; font-size: 18pt; qproperty-alignment: AlignCenter;}')
                 dataLayout.addWidget(lab)
                 line.my_label = lab
-                
+
             # add to the tab
             self.tabs[label].layout().addLayout(layout)
             self.tabs[label].layout().addLayout(dataLayout)
-        
+
+
 def make():
     demo = LabRADPlotWidget3(None, path=["", "DR", "Danko"], dataset=25)
     demo.resize(1000, 800)
@@ -507,12 +594,11 @@ def make():
 
 def main(args):
     app = Qt.QApplication(args)
-    
+
     import qt4reactor
     qt4reactor.install()
     from twisted.internet import reactor
-    import labrad, labrad.util
-    
+
     reactor.runReturn()
     demo = make()
     v = app.exec_()

--- a/GUIs/SuperMonitor.py
+++ b/GUIs/SuperMonitor.py
@@ -5,12 +5,13 @@ New and improved DR monitor.
 '''
 
 import sys
+from twisted.internet.defer import inlineCallbacks, Deferred
 
 import PyQt4.Qt as Qt
 import PyQt4.QtGui as QtGui
-from twisted.internet.defer import inlineCallbacks
+import PyQt4.QtCore as QtCore
 
-from ADR.LabRADPlotWidget3 import LabRADPlotWidget3
+from LabRADPlotWidget3 import LabRADPlotWidget3
 
 DEFAULT = 'Vince'
 BASE_PATH = ['', 'DR']
@@ -29,6 +30,7 @@ class AppForm(Qt.QMainWindow):
             import labrad.async
             cxnDef = labrad.async.connectAsync(name=labrad.util.getNodeName() + ' SuperMonitor')
         cxnDef.addCallback(self.set_cxn)
+        cxnDef.addErrback(self.err_cxn)
     
     def init_qt(self):
         self.setWindowTitle('SuperMonitor')
@@ -61,9 +63,31 @@ class AppForm(Qt.QMainWindow):
         self.plotWidget.maxPointsLE.setText('1000')
 
     @inlineCallbacks
+    def err_cxn(self, failure):
+        print "Connection failure!"
+        message = "Could not connect to LabRAD:\n" + ':\n'.join(failure.getErrorMessage().split(':'))
+        label = Qt.QLabel(message)
+        label.setAlignment(QtCore.Qt.AlignHCenter)
+        label.setStyleSheet("* {font-weight: bold; font-size: 15pt;}")
+        self.setCentralWidget(label)
+        # wait and do it again
+        d = Deferred()
+        reactor.callLater(1, d.callback, 1)
+        yield d
+        try:
+            import labrad
+            cxnDef = labrad.connectAsync(name=labrad.util.getNodeName() + ' SuperMonitor')
+        except AttributeError:
+            import labrad.async
+            cxnDef = labrad.async.connectAsync(name=labrad.util.getNodeName() + ' SuperMonitor')
+        cxnDef.addCallback(self.set_cxn)
+        cxnDef.addErrback(self.err_cxn)
+
+
+    @inlineCallbacks
     def check_dr_logger(self, node):
         running = yield node.running_servers()
-        if LOGGER_SERVER not in [x[0] for x in running]:
+        if LOGGER_SERVER not in [x[0] for x in running] + list(self.cxn.servers):
             print "%s not running, attempting to start... " % LOGGER_SERVER,
             try:
                 yield node.start(LOGGER_SERVER)
@@ -85,9 +109,7 @@ class AppForm(Qt.QMainWindow):
 if __name__ == '__main__':        
     # look for DR name in args
     if len(sys.argv) > 1:
-        default = sys.argv[1]
-    else:
-        default = DEFAULT
+        DEFAULT = sys.argv[1]
     app = Qt.QApplication(sys.argv)
     import qt4reactor
     qt4reactor.install()

--- a/GUIs/__init__.py
+++ b/GUIs/__init__.py
@@ -1,0 +1,1 @@
+__author__ = 'pomalley'

--- a/dr_logger.py
+++ b/dr_logger.py
@@ -34,35 +34,63 @@ timeout = 20
 
 import time
 
-from twisted.internet.defer import inlineCallbacks, returnValue, Deferred
+from twisted.internet.defer import inlineCallbacks, returnValue
 from twisted.internet.task import LoopingCall
 
-from labrad import types as T, gpib
+from labrad import types as T
 from labrad.server import setting
 from labrad.gpib import DeviceWrapper, DeviceServer
-from labrad.errors import NoSuchDeviceError
-
+from labrad.errors import NoSuchDeviceError, Error
+from labrad.units import Unit, Value
 
 CONFIG_PATH = ['', 'Servers', 'DR Logger']
 DIODE_LIST = ["4Kin", "4Kout", "77K", "Ret", "Mix", "Xchg", "Still", "Pot"]
 
+
+class NoMKSDataError(Error):
+    pass
+
+
+class ServerNotFoundError(Error):
+    pass
+
+
 class WatchedServer(object):
     server_name = 'none'
+
     def __init__(self, name, cxn, ctx, device=None):
-        self.name=name
+        self.name = name
         self.cxn = cxn
         self.ctx = ctx
         self.device = device
         self.server = None
         self.active = False
+
     def get_variables(self):
-        ''' Get the variables (for the data vault) logged by this server. '''
+        """ Get the variables (for the data vault) logged by this server.
+
+        This is called on dataset creation to figure out how to define the dataset.
+        :return: list of strings, one per variable, of the form "label (legend) [unit]"
+        :rtype: list[str]
+        """
         raise NotImplementedError()
-        
+
+    def _take_point(self):
+        """ Get data from the device.
+
+        This is called once per cycle to record the data.
+        The return values must correspond with those of get_variables.
+        :return: list of values, one per variable.
+        :rtype: list[Value]
+        """
+        raise NotImplementedError()
+
     @inlineCallbacks
     def select_device(self):
         devs = yield self.server.list_devices(context=self.ctx)
         print "looking for device %s" % self.device
+        if self.device is None:
+            yield self.server.select_device(context=self.ctx)
         if self.device in [x[1] for x in devs]:
             yield self.server.select_device(self.device, context=self.ctx)
         else:
@@ -76,13 +104,19 @@ class WatchedServer(object):
 
     @inlineCallbacks
     def take_point(self):
-        ''' Take a single data point. '''
-        if not self.server:
-            self.server = self.cxn[self.name]    
+        """ Take a single data point.
+
+        Call self._take_point, and handle server selection and device selection.
+        """
         try:
+            self.server = self.cxn[self.name]
             r = yield self._take_point()
             self.active = True
             returnValue(r)
+        except KeyError as err:
+            raise ServerNotFoundError(
+                "'{}' server not found".format(self.name), payload=err
+            )
         except T.Error as err:
             self.active = False
             if 'DeviceNotSelectedError' in err.msg:
@@ -92,28 +126,28 @@ class WatchedServer(object):
                 returnValue(r)
             else:
                 raise err
-    def _take_point(self):
-        raise NotImplementedError()
-        
+
+
+# noinspection PyAttributeOutsideInit
 class MKS(WatchedServer):
-    ''' for MKS servers, we have an optional "device" argument in the form of
+    """ for MKS servers, we have an optional "device" argument in the form of
     (reading_name, multiplier), which tells us which reading to convert into
     a He flow.
-    '''
+    """
     server_name = 'mks_gauge_server'
+
     @inlineCallbacks
     def _take_point(self):
         r = yield self.server.get_readings(context=self.ctx)
         r = list(r)
         if not hasattr(self, 'channel'):
             yield self.setup_he_flow()
+        if not r:
+            raise NoMKSDataError("MKS server did not return data.")
         if self.channel != -1:
-            try:
-                r.append(self.multiplier * r[self.channel])
-            except IndexError:
-                print "Bad point"
+            r.append(self.multiplier * r[self.channel])
         returnValue(r)
-        
+
     @inlineCallbacks
     def get_variables(self):
         point = yield self.take_point()
@@ -124,7 +158,7 @@ class MKS(WatchedServer):
         if self.channel != -1:
             rv.append('He Flow (LHe) [L/h]')
         returnValue(rv)
-        
+
     @inlineCallbacks
     def setup_he_flow(self):
         if self.device:
@@ -140,22 +174,27 @@ class MKS(WatchedServer):
                 print "ERROR: could not find gauge reading named '%s'" % self.device[0]
         else:
             self.channel = -1
-        
+
+
 class MKSHack(MKS):
     server_name = 'mks_gauge_server_testhack'
-    
-        
+
+
 class Diodes(WatchedServer):
     server_name = 'lakeshore_diodes'
+
     @inlineCallbacks
     def _take_point(self):
         r = yield self.server.temperatures(context=self.ctx)
         returnValue(r)
+
     def get_variables(self):
         return ['%s (Diode) [K]' % x for x in DIODE_LIST]
-        
+
+
 class Ruox(WatchedServer):
     server_name = 'lakeshore_ruox'
+
     @inlineCallbacks
     def _take_point(self):
         p = self.server.packet(context=self.ctx)
@@ -165,33 +204,45 @@ class Ruox(WatchedServer):
         temps = [x[0] for x in result.temperatures]
         res = [x[0] for x in result.resistances]
         returnValue(temps + res)
-        
+
     @inlineCallbacks
     def get_variables(self):
-        yield self.take_point()   # make sure we're connected
+        yield self.take_point()  # make sure we're connected
         t = yield self.server.named_temperatures(context=self.ctx)
         temp_vars = ['%s (Ruox) [%s]' % (x[0], str(x[1][0].unit)) for x in t]
         r = yield self.server.named_resistances(context=self.ctx)
         res_vars = ['%s (Ruox Res) [%s]' % (x[0], str(x[1][0].unit)) for x in r]
-        returnValue(temp_vars+res_vars)
+        returnValue(temp_vars + res_vars)
 
-WATCHERS = [MKS, MKSHack, Diodes, Ruox]
 
+# some tomfoolery to pull together all our watchers
+WATCHERS = []
+for obj in vars().values():
+    try:
+        if issubclass(obj, WatchedServer) and obj is not WatchedServer:
+            WATCHERS.append(obj)
+    except TypeError:
+        pass
+print "Found these watchers: ", WATCHERS
+
+
+# noinspection PyAttributeOutsideInit
 class DRLogger(DeviceWrapper):
-    #@inlineCallbacks
+    # @inlineCallbacks
     def connect(self, *args, **kwargs):
-        ''' args: cxn (e.g. vince, jules, ivan)
-            kwargs: values from registry under that name. '''
-        #self.name = assigned by LabRAD stuff
+        """ args: cxn (e.g. vince, jules, ivan)
+            kwargs: values from registry under that name. """
+        # self.name = assigned by LabRAD stuff
         print "Creating DR Logger for %s" % self.name
         self.cxn = args[0]
         self.ctx = self.cxn.context()
         self.watchers = []
         self.data_vault = None
+        self.errors = []
         self.dvPath = kwargs.pop('dvPath', ['', 'DR', self.name])
         self.datasetName = kwargs.pop('datasetName', '%s log - [t]' % self.name)
         self.timeInterval = kwargs.pop('timeInterval', 1.0)
-        self.currentDay = time.strftime("%d")
+        self.currentDay = ''
         # now make our watchers
         for k, v in kwargs.iteritems():
             server_name = v[0]
@@ -208,11 +259,11 @@ class DRLogger(DeviceWrapper):
                 print "Found watcher for %s" % server_name
                 self.watchers.append(cls(server_name, self.cxn, self.ctx, device=devName))
             else:
-                print "ERROR: No watcher class found for server: %s" % server_name
-                
+                raise ValueError("ERROR: No watcher class found for:", server_name)
+
         self.isLogging = False
         self.logging(True)  # start logging
-            
+
     @inlineCallbacks
     def logging(self, start):
         if not self.isLogging and start:
@@ -230,10 +281,13 @@ class DRLogger(DeviceWrapper):
                 pass
             print 'loop stopped'
             self.isLogging = False
-            
+
     @inlineCallbacks
     def shutdown(self):
         yield self.logging(False)
+
+    def new_dataset(self):
+        self.data_vault = None
 
     @inlineCallbacks
     def make_dataset(self):
@@ -248,22 +302,29 @@ class DRLogger(DeviceWrapper):
             deps.extend(r)
         print "Indep vars: %s" % str(indeps)
         print "Dependent vars: %s" % str(deps)
-        
+
         yield self.data_vault.new(name, indeps, deps, context=self.ctx)
-        
+
     @inlineCallbacks
     def take_point(self):
-        try:
-            # gather data
-            data = [time.time()*T.U.s]
-            for w in self.watchers:
+        # gather data
+        data = [time.time() * Unit('s')]
+        errors = []
+        for w in self.watchers:
+            try:
                 r = yield w.take_point()
                 data.extend(r)
-            # strip units
-            data = [x._value for x in data]
-            # did the day roll over?
-            if self.currentDay != time.strftime("%d"):
-                self.new_dataset()
+            except T.Error as err:
+                errors.append((w.server_name, err.msg))
+        if errors:
+            self.errors = errors
+            returnValue(None)
+        # strip units
+        data = [x[x.unit] for x in data]
+        # did the day roll over?
+        if self.currentDay != time.strftime("%d"):
+            self.new_dataset()
+        try:
             # make dataset if first time
             if not self.data_vault:
                 yield self.make_dataset()
@@ -271,14 +332,15 @@ class DRLogger(DeviceWrapper):
             yield self.data_vault.add(data, context=self.ctx)
         except T.Error as err:
             if 'NoDatasetError' in err.msg:
-                yield self.make_dataset()
-                yield self.data_vault.add(data, context=self.ctx)
+                try:
+                    yield self.make_dataset()
+                    yield self.data_vault.add(data, context=self.ctx)
+                except T.Error as err:
+                    errors.append(("Data Vault", str(err)))
             else:
-                print "ERROR in take_point:"
-                print err
-                
-    def new_dataset(self):
-        self.data_vault = None
+                errors.append(("General", str(err)))
+        self.errors = errors
+
 
 class DRLoggerServer(DeviceServer):
     name = 'DR Logger'
@@ -287,8 +349,8 @@ class DRLoggerServer(DeviceServer):
 
     @inlineCallbacks
     def findDevices(self):
-        ''' finds all configurations in CONFIG_PATH and returns (name, (cxn,), serverDict) '''
-        deviceList=[]
+        """ finds all configurations in CONFIG_PATH and returns (name, (cxn,), serverDict) """
+        deviceList = []
         reg = self.client.registry
         yield reg.cd(CONFIG_PATH)
         resp = yield reg.dir()
@@ -309,43 +371,61 @@ class DRLoggerServer(DeviceServer):
                 if "node_" + node.lower() not in self.client.servers:
                     missingNodes.append(node)
             if not missingNodes:
-                deviceList.append((name,(self.client,), serverDict))
+                deviceList.append((name, (self.client,), serverDict))
             else:
                 print "device %s missing nodes %s" % (name, str(list(set(missingNodes))))
-            yield reg.cd(1)                
+            yield reg.cd(1)
         returnValue(deviceList)
-        
+
     @setting(10, "Take Point")
     def take_point(self, c):
-        ''' Take a single data point. '''
+        """ Take a single data point. """
         self.selectedDevice(c).take_point()
-        
+
     @setting(11, "New Dataset")
     def new_dataset(self, c):
-        ''' Start a new dataset. '''
+        """ Start a new dataset. """
         self.selectedDevice(c).newDataset()
-        
+
     @setting(12, 'Logging', start='b', returns='b')
     def logging(self, c, start=None):
-        ''' Get/set whether we are currently logging. '''
+        """ Get/set whether we are currently logging. """
         dev = self.selectedDevice(c)
         if start is not None:
             yield dev.logging(start)
         returnValue(dev.isLogging)
-        
+
     @setting(13, 'Time Interval', ti='v[s]', returns='v[s]')
     def time_interval(self, c, ti=None):
-        ''' Get/set the logging time interval. '''
+        """ Get/set the logging time interval. """
         dev = self.selectedDevice(c)
         if ti is not None:
-            dev.timeInterval = ti
+            dev.timeInterval = ti['s']
             if dev.isLogging:
                 yield dev.logging(False)
                 yield dev.logging(True)
-        returnValue(dev.timeInterval*T.U.s)
+        returnValue(Value(dev.timeInterval, 's'))
+
+    @setting(14, 'Errors', returns='*(s, s)')
+    def errors(self, c):
+        """ Retrieve outstanding errors.
+
+        Each error is given as a pair of strings:
+        (source or type, error message)
+        """
+        dev = self.selectedDevice(c)
+        return dev.errors
+
+    @setting(15, 'Current Time', returns='v['']')
+    def current_time(self, c):
+        """ Return the current time, in seconds (i.e. time.time()).
+        """
+        return time.time()
+
 
 __server__ = DRLoggerServer()
 
 if __name__ == '__main__':
     from labrad import util
+
     util.runServer(__server__)

--- a/serial_server.py
+++ b/serial_server.py
@@ -108,7 +108,7 @@ class SerialServer(LabradServer):
         if not port:
             for i in range(len(self.SerialPorts)):
                 try:
-                    c['PortObject'] = Serial('\\\\.\\' + self.SerialPorts[i], timeout=0)
+                    c['PortObject'] = Serial('\\\\.\\' + self.SerialPorts[i], timeout=0.01)
                     break
                 except SerialException:
                     pass
@@ -116,7 +116,7 @@ class SerialServer(LabradServer):
                 raise NoPortsAvailableError()
         else:
             try:
-                c['PortObject'] = Serial('\\\\.\\' + port, timeout=0)
+                c['PortObject'] = Serial('\\\\.\\' + port, timeout=0.01)
             except SerialException, e:
                 if e.message.find('cannot find') >= 0:
                     raise Error(code=1, msg=e.message)


### PR DESCRIPTION
I've tried to make the DR logger better about handling dead servers and displaying errors.

I've also changed the serial and mks servers to make the MKS server report 0 when the gauges read "LO" and the full scale when "OFF". Having NaNs in the data vault is really annoying. If there is a serial error, though, there still will be NaNs so you know if something is broken.

This includes commits from #44 so that needs to happen first.