### PR TITLE
ADR GUI checkbox hiding

### DIFF
--- a/GUIs/ADR/ADRcontrol2.py
+++ b/GUIs/ADR/ADRcontrol2.py
@@ -534,7 +534,7 @@ class TestWindow(QtGui.QMainWindow):
             yield self.adr_server.set_state(var, val * unit)
 
     def setDateTimeLabels(self, dateLabel, timeLabel, t):
-        if hasattr(t, 'unit'):
+        if hasattr(t, 'unit') and t.unit != '':
             if t['s'] > 1:
                 lt = time.localtime(t['s'])
                 dateLabel.setText("%s/%s" % (lt.tm_mon, lt.tm_mday))

--- a/GUIs/ADR/LabRADPlotWidget2.py
+++ b/GUIs/ADR/LabRADPlotWidget2.py
@@ -85,12 +85,26 @@ class LabRADPlotWidget2(Qt.QWidget):
         self.tempUnitsCB = Qt.QCheckBox("Temperature in F")
         self.tempUnitsCB.setChecked(False)
         vl.addWidget(self.tempUnitsCB)
+
+        self.hideUncheckedCB = Qt.QCheckBox("Hide unchecked")
+        self.hideUncheckedCB.setChecked(False)
+        self.hideUncheckedCB.toggled.connect(self.hideUncheckedCallback)
+        vl.addWidget(self.hideUncheckedCB)
         
         optGB = Qt.QGroupBox("Options")
         optGB.setCheckable(False)
         optGB.setLayout(vl)
         optGB.setSizePolicy(Qt.QSizePolicy.Fixed, Qt.QSizePolicy.Fixed)
         self.groupBoxLayout.addWidget(optGB, 0, QtCore.Qt.AlignTop)
+
+    def hideUncheckedCallback(self, toggled):
+        if toggled:
+            for cb in self.checkBoxes:
+                if not cb.isChecked():
+                    cb.setVisible(False)
+        else:
+            for cb in self.checkBoxes:
+                cb.setVisible(True)
         
     def setCxn(self, cxn):
         self.cxn = cxn
@@ -275,6 +289,8 @@ class LabRADPlotWidget2(Qt.QWidget):
                         gb.setChecked(False)
                     gb.leaveEvent(None)
             self.groupBoxCallback()
+        self.hideUncheckedCB.setChecked(True)
+        self.hideUncheckedCallback(True)
         #if 'ylimits' in self.settings.keys():
             #for name, lim in ylimits:
                 
@@ -293,7 +309,7 @@ class LabRADPlotWidget2(Qt.QWidget):
             if len(self.plotLabels[legend]) == 1:
                 gb = Qt.QGroupBox("%s (%s)" % (legend, self.plotLabels[legend][0]))
             else:
-                gb = HidingGroupBox(legend)
+                gb = Qt.QGroupBox(legend)
                 for label in self.plotLabels[legend]:
                     l = self.lines[self.plotIndices[legend][self.plotLabels[legend].index(label)] - 1]
                     cb = Qt.QCheckBox(label)


### PR DESCRIPTION
There is now an option to hide checkboxes for un-watched lines, rather than showing them on mouseover (which turned out to be annoying). This fixes #21, finally.