### PR TITLE
Ensure Hittite frequency write is integer number in Hz

### DIFF
--- a/HittiteT2100/hittite_T2100.py
+++ b/HittiteT2100/hittite_T2100.py
@@ -65,9 +65,9 @@ class HittiteWrapper(GPIBDeviceWrapper):
         
     @inlineCallbacks
     def setFrequency(self, f):
-        f = f['Hz']
+        f = int(f['Hz'])
         if self.frequency != f:
-            yield self.write('SOUR:FREQ:FIX %f' % f)
+            yield self.write('SOUR:FREQ:FIX %d' % f)
             self.frequency = f
     
     @inlineCallbacks


### PR DESCRIPTION
There is a deeper issue here: servers which set hardware parameters should *always* read back the parameter they try to write and **fail** if the attempted write value does not match the read-back.

I think the change proposed here is better than what was there before because in the old way the result was that the write would silently do nothing. Now you at least get a frequency which is within 1 Hz of what you wanted. I'm all ears if folks think this sucks. If we had a LabRAD type for unit-checked integers this would be much easier to deal with, but we don't. Ideas?