### PR TITLE
GHzFPGA.run: Enable ADC Average Mode

### DIFF
--- a/GHzDACs/ghz_fpga_server.py
+++ b/GHzDACs/ghz_fpga_server.py
@@ -1361,34 +1361,39 @@ class FPGAServer(DeviceServer):
                      setupState=[]):
         """Executes a sequence on one or more boards.
 
-        reps:
-            specifies the number of repetitions ('stats') to perform
-            (rounded up to the nearest multiple of 30).
+        Args:
+            reps:
+                specifies the number of repetitions ('stats') to perform
+                (rounded up to the nearest multiple of 30).
+            getTimingData:
+                specifies whether timing data should be returned.
+                the timing data will be returned for those boards
+                specified by the "Timing Order" setting, and in
+                the order specified there as well.
+            setupPkts:
+                specifies packets to be sent to other servers before this
+                sequence is run, e.g. to set the microwave frequency.
+            setupState:
+                a list of strings describing the setup state for this point.
+                if this matches the last setup state used (up to reordering),
+                the setup packets will not be sent for this point.  For example,
+                the setupState might describe the amplitude and frequency of
+                the various microwave sources for this sequence.
 
-        getTimingData:
-            specifies whether timing data should be returned.
-            the timing data will be returned for those boards
-            specified by the "Timing Order" setting, and in
-            the order specified there as well.
+        Returns:
+            If ADC boards all in average mode, data returned as a *3i. The three
+            indices are:
+                (board index in timing order, I/Q, time sample index).
 
-        setupPkts:
-            specifies packets to be sent to other servers before this
-            sequence is run, e.g. to set the microwave frequency.
-            
-        setupState:
-            a list of strings describing the setup state for this point.
-            if this matches the last setup state used (up to reordering),
-            the setup packets will not be sent for this point.  For example,
-            the setupState might describe the amplitude and frequency of
-            the various microwave sources for this sequence.
-            
-        If only DAC boards are run and all boards return the same number of
-        results (because all boards have the same number of timer calls),
-        then a 2D list of results of type *2w will be returned.  Otherwise,
-        a cluster of results will be returned, in the order specified by
-        timing order.  Individual DAC boards always return *w; ADC boards in
-        average mode return (*i,{I} *i{Q}); and ADC boards in demodulate
-        mode also return (*i,{I} *i{Q}) for each channel.
+            If ADC boards all in demodulate mode, data returned as a *4i.
+            The four indices label:
+                (demod channel, stat, retrigger, I/Q).
+            retrigger indexes multiple triggers in a sequence.
+
+            If only DACs present, we return no data.
+
+            ADC boards must be either all in average mode or all in demodulate
+            mode.
         """
         # determine timing order
         if getTimingData:

--- a/GHzDACs/ghz_fpga_server.py
+++ b/GHzDACs/ghz_fpga_server.py
@@ -177,7 +177,7 @@ cmdTime_cycles does not properly estimate sram length
 ### BEGIN NODE INFO
 [info]
 name = GHz FPGAs
-version = 4.0.1
+version = 4.0.2
 description = Talks to DAC and ADC boards
 
 [startup]
@@ -753,6 +753,9 @@ class BoardGroup(object):
                         channel = int(channel)
                     elif 'DAC' in dataChannelName:
                         raise RuntimeError("DAC data readback not supported")
+                    elif 'ADC' in dataChannelName:
+                        boardName = dataChannelName
+                        channel = None
                     else:
                         raise RuntimeError('channel format not understood')
                     
@@ -760,7 +763,6 @@ class BoardGroup(object):
                     # cached result.
                     if boardName in extractedData:
                         extracted = extractedData[boardName]
-                        extracted = extracted[0][channel]
                     # Otherwise, extract the data, cache it, and add the relevant part
                     # to the list of returned data.
                     else:
@@ -782,10 +784,10 @@ class BoardGroup(object):
                         # If this is an ADC demod channel, grab that channel's
                         # data only
                         # print("fpga_server: extracted: %s"%(extracted,))
-                        extracted = extracted[0]
                         # print("fpga_server: extacted no pkt counters: %s"%(type(extracted),))
                         # print("fpga_server: channel: %d"%(channel,))
-                        extracted = extracted[channel]
+                    if channel != None:
+                        extracted = extracted[0][channel]
                     answers.append(extracted)
                 returnValue(tuple(answers))
         finally:
@@ -1363,7 +1365,7 @@ class FPGAServer(DeviceServer):
     @setting(50, 'Run Sequence', reps='w', getTimingData='b',
                              setupPkts='?{(((ww), s, ((s?)(s?)(s?)...))...)}',
                              setupState='*s',
-                             returns=['*4i',''])
+                             returns=['*4i','*3i',''])
     def run_sequence(self, c, reps=30, getTimingData=True, setupPkts=[],
                      setupState=[]):
         """Executes a sequence on one or more boards.


### PR DESCRIPTION
Fixes #100.

In FPGA server/run (and hence run_sequence), if ADC in average mode so that no demod channel specified, raised 'channel format not understood' exception. Now add elif case in getTimingData so if ADC is present in channel name but not :: (for demodulation), can still return data. Move calls to channel to if statement for if channel defined. Amend return format type for run_sequence to also allow '*3i' for average mode data.

Note that in going between demod and average modes (although in different scans & calls to run_sequence), it seems to work fine (although it's possible I might not be seeing/knowing what @JulianSKelly was referring to).