### PR TITLE
Make averaging, dithering, and zeroing optional and off by default.

### DIFF
--- a/Qubit Server/dev/src/main/java/org/labrad/qubits/QubitContext.java
+++ b/Qubit Server/dev/src/main/java/org/labrad/qubits/QubitContext.java
@@ -559,9 +559,12 @@ public class QubitContext extends AbstractServerContext {
           + "microwave quadratures.  The length of the data should "
           + "match the length of the current SRAM block.  "
           + "An optional boolean specifies whether the data "
-          + "should be deconvolved (default: true)."
-          + "If deconvolve=false, the data can be specified as DAC-ready"
-          + "I and Q integers.")
+          + "should be deconvolved (default: true).  "
+          + "If deconvolve=false, the data can be specified as DAC-ready "
+          + "I and Q integers. "
+          + "If zeroEnds is true (the default), then the first and last "
+          + "4 nanoseconds of the deconvolved sequence will be set to the "
+          + "deconvolved zero value, to ensure microwaves are turned off.")
   public void sram_iq_data(
       @Accepts({"s", "ss"}) Data id,
       @Accepts("*c") Data vals
@@ -605,7 +608,10 @@ public class QubitContext extends AbstractServerContext {
           + "The data is specified as a list of complex numbers, "
           + "with the real and imaginary parts giving the I and Q "
           + "microwave quadratures.  The length of the data should "
-          + "match the length of the current SRAM block.")
+          + "match the length of the current SRAM block.  "
+          + "If zeroEnds is true (the default), then the first and last "
+          + "4 nanoseconds of the deconvolved sequence will be set to the "
+          + "deconvolved zero value, to ensure microwaves are turned off.")
   public void sram_iq_data_fourier(
       @Accepts({"s", "ss"}) Data id,
       @Accepts("*c") Data vals,
@@ -636,9 +642,13 @@ public class QubitContext extends AbstractServerContext {
           + "\n\n"
           + "The length of the data should match the length of the "
           + "current SRAM block.  An optional boolean specifies "
-          + "whether the data should be deconvolved (default: true)."
+          + "whether the data should be deconvolved (default: true).  "
           + "If deconvolve=false, the data can be supplied as DAC-ready "
-          + "integers.")
+          + "integers.  "
+          + "If averageEnds is true (the default), then the first and last "
+          + "4 nanoseconds of the deconvolved sequence will be averaged and "
+          + "set to the same value, to ensure the DAC outputs a constant "
+          + "after the sequence is run.")
   public void sram_analog_data(
       @Accepts({"s", "ss"}) Data id,
       @Accepts("*v") Data vals
@@ -682,7 +692,11 @@ public class QubitContext extends AbstractServerContext {
           + "\n\n"
           + "Because this represents real data, we only need half as many samples.  "
           + "In particular, for a sequence of length n, the fourier data given "
-          + "here must have length n/2+1 (n even) or (n+1)/2 (n odd).")
+          + "here must have length n/2+1 (n even) or (n+1)/2 (n odd)."
+          + "If averageEnds is true (the default), then the first and last "
+          + "4 nanoseconds of the deconvolved sequence will be averaged and "
+          + "set to the same value, to ensure the DAC outputs a constant "
+          + "after the sequence is run.")
   public void sram_analog_fourier_data(
       @Accepts({"s", "ss"}) Data id,
       @Accepts("*c") Data vals,

--- a/Qubit Server/dev/src/main/java/org/labrad/qubits/QubitContext.java
+++ b/Qubit Server/dev/src/main/java/org/labrad/qubits/QubitContext.java
@@ -562,22 +562,34 @@ public class QubitContext extends AbstractServerContext {
           + "should be deconvolved (default: true)."
           + "If deconvolve=false, the data can be specified as DAC-ready"
           + "I and Q integers.")
-  public void sram_iq_data(@Accepts({"s", "ss"}) Data id,
-      @Accepts("*c") Data vals) {
+  public void sram_iq_data(
+      @Accepts({"s", "ss"}) Data id,
+      @Accepts("*c") Data vals
+  ) {
     sram_iq_data(id, vals, true);
-    sramDirty = true;
   }
   @SettingOverload
-  public void sram_iq_data(@Accepts({"s", "ss"}) Data id,
+  public void sram_iq_data(
+      @Accepts({"s", "ss"}) Data id,
       @Accepts({"*c", "(*i{I}, *i{Q})"}) Data vals,
-      boolean deconvolve) {
+      boolean deconvolve
+  ) {
+    sram_iq_data(id, vals, deconvolve, true);
+  }
+  @SettingOverload
+  public void sram_iq_data(
+      @Accepts({"s", "ss"}) Data id,
+      @Accepts({"*c", "(*i{I}, *i{Q})"}) Data vals,
+      boolean deconvolve,
+      boolean zeroEnds
+  ) {
     IqChannel ch = getChannel(id, IqChannel.class);
     if (vals.isCluster()) {
       Preconditions.checkArgument(!deconvolve, "Must not deconvolve if providing DAC'ified IQ data.");
       ch.addData(new IqDataTime(vals.get(0).getIntArray(), vals.get(1).getIntArray()));
     } else {
       ComplexArray c = ComplexArray.fromData(vals);
-      ch.addData(new IqDataTime(c, !deconvolve));
+      ch.addData(new IqDataTime(c, !deconvolve, zeroEnds));
     }
     sramDirty = true;
   }
@@ -594,12 +606,23 @@ public class QubitContext extends AbstractServerContext {
           + "with the real and imaginary parts giving the I and Q "
           + "microwave quadratures.  The length of the data should "
           + "match the length of the current SRAM block.")
-  public void sram_iq_data_fourier(@Accepts({"s", "ss"}) Data id,
+  public void sram_iq_data_fourier(
+      @Accepts({"s", "ss"}) Data id,
       @Accepts("*c") Data vals,
-      @Accepts("v[ns]") double t0) {
+      @Accepts("v[ns]") double t0
+  ) {
+    sram_iq_data_fourier(id, vals, t0, true);
+  }
+  @SettingOverload
+  public void sram_iq_data_fourier(
+      @Accepts({"s", "ss"}) Data id,
+      @Accepts("*c") Data vals,
+      @Accepts("v[ns]") double t0,
+      boolean zeroEnds
+  ) {
     IqChannel ch = getChannel(id, IqChannel.class);
     ComplexArray c = ComplexArray.fromData(vals);
-    ch.addData(new IqDataFourier(c, t0));
+    ch.addData(new IqDataFourier(c, t0, zeroEnds));
     sramDirty = true;
   }
 
@@ -614,21 +637,33 @@ public class QubitContext extends AbstractServerContext {
           + "The length of the data should match the length of the "
           + "current SRAM block.  An optional boolean specifies "
           + "whether the data should be deconvolved (default: true)."
-          + "If deconvolve=false, the data can be supplied as DAC-ready"
-          + "integers")
-  public void sram_analog_data(@Accepts({"s", "ss"}) Data id,
-      @Accepts("*v") Data vals) {
+          + "If deconvolve=false, the data can be supplied as DAC-ready "
+          + "integers.")
+  public void sram_analog_data(
+      @Accepts({"s", "ss"}) Data id,
+      @Accepts("*v") Data vals
+  ) {
     sram_analog_data(id, vals, true);
-    sramDirty = true;
   }
   @SettingOverload
-  public void sram_analog_data(@Accepts({"s", "ss"}) Data id,
+  public void sram_analog_data(
+      @Accepts({"s", "ss"}) Data id,
       @Accepts({"*v", "*i"}) Data vals,
-      boolean deconvolve) {
+      boolean deconvolve
+  ) {
+    sram_analog_data(id, vals, deconvolve, true);
+  }
+  @SettingOverload
+  public void sram_analog_data(
+      @Accepts({"s", "ss"}) Data id,
+      @Accepts({"*v", "*i"}) Data vals,
+      boolean deconvolve,
+      boolean averageEnds
+  ) {
     AnalogChannel ch = getChannel(id, AnalogChannel.class);
     if (vals.matchesType("*v")) {
       double[] arr = vals.getValueArray();
-      ch.addData(new AnalogDataTime(arr, !deconvolve));
+      ch.addData(new AnalogDataTime(arr, !deconvolve, averageEnds));
     } else {
       Preconditions.checkArgument(!deconvolve, "Must not deconvolve if providing DAC'ified data.");
       int[] arr = vals.getIntArray();
@@ -648,12 +683,23 @@ public class QubitContext extends AbstractServerContext {
           + "Because this represents real data, we only need half as many samples.  "
           + "In particular, for a sequence of length n, the fourier data given "
           + "here must have length n/2+1 (n even) or (n+1)/2 (n odd).")
-  public void sram_analog_fourier_data(@Accepts({"s", "ss"}) Data id,
+  public void sram_analog_fourier_data(
+      @Accepts({"s", "ss"}) Data id,
       @Accepts("*c") Data vals,
-      @Accepts("v[ns]") double t0) {
+      @Accepts("v[ns]") double t0
+  ) {
+    sram_analog_fourier_data(id, vals, t0, true);
+  }
+  @SettingOverload
+  public void sram_analog_fourier_data(
+      @Accepts({"s", "ss"}) Data id,
+      @Accepts("*c") Data vals,
+      @Accepts("v[ns]") double t0,
+      boolean averageEnds
+  ) {
     AnalogChannel ch = getChannel(id, AnalogChannel.class);
     ComplexArray c = ComplexArray.fromData(vals);
-    ch.addData(new AnalogDataFourier(c, t0));
+    ch.addData(new AnalogDataFourier(c, t0, averageEnds));
     sramDirty = true;
   }
 

--- a/Qubit Server/dev/src/main/java/org/labrad/qubits/QubitContext.java
+++ b/Qubit Server/dev/src/main/java/org/labrad/qubits/QubitContext.java
@@ -562,7 +562,7 @@ public class QubitContext extends AbstractServerContext {
           + "should be deconvolved (default: true).  "
           + "If deconvolve=false, the data can be specified as DAC-ready "
           + "I and Q integers. "
-          + "If zeroEnds is true (the default), then the first and last "
+          + "If zeroEnds=true (default: true), then the first and last "
           + "4 nanoseconds of the deconvolved sequence will be set to the "
           + "deconvolved zero value, to ensure microwaves are turned off.")
   public void sram_iq_data(
@@ -609,7 +609,7 @@ public class QubitContext extends AbstractServerContext {
           + "with the real and imaginary parts giving the I and Q "
           + "microwave quadratures.  The length of the data should "
           + "match the length of the current SRAM block.  "
-          + "If zeroEnds is true (the default), then the first and last "
+          + "If zeroEnds=true (default: true), then the first and last "
           + "4 nanoseconds of the deconvolved sequence will be set to the "
           + "deconvolved zero value, to ensure microwaves are turned off.")
   public void sram_iq_data_fourier(
@@ -645,10 +645,13 @@ public class QubitContext extends AbstractServerContext {
           + "whether the data should be deconvolved (default: true).  "
           + "If deconvolve=false, the data can be supplied as DAC-ready "
           + "integers.  "
-          + "If averageEnds is true (the default), then the first and last "
+          + "If averageEnds=true (default: true), then the first and last "
           + "4 nanoseconds of the deconvolved sequence will be averaged and "
           + "set to the same value, to ensure the DAC outputs a constant "
-          + "after the sequence is run.")
+          + "after the sequence is run.  "
+          + "If dither=true (default: false), then the deconvolved data "
+          + "will be dithered by adding random noise to reduce quantization "
+          + "noise (see http://en.wikipedia.org/wiki/Dither).")
   public void sram_analog_data(
       @Accepts({"s", "ss"}) Data id,
       @Accepts("*v") Data vals
@@ -670,10 +673,20 @@ public class QubitContext extends AbstractServerContext {
       boolean deconvolve,
       boolean averageEnds
   ) {
+    sram_analog_data(id, vals, deconvolve, averageEnds, false);
+  }
+  @SettingOverload
+  public void sram_analog_data(
+      @Accepts({"s", "ss"}) Data id,
+      @Accepts({"*v", "*i"}) Data vals,
+      boolean deconvolve,
+      boolean averageEnds,
+      boolean dither
+  ) {
     AnalogChannel ch = getChannel(id, AnalogChannel.class);
     if (vals.matchesType("*v")) {
       double[] arr = vals.getValueArray();
-      ch.addData(new AnalogDataTime(arr, !deconvolve, averageEnds));
+      ch.addData(new AnalogDataTime(arr, !deconvolve, averageEnds, dither));
     } else {
       Preconditions.checkArgument(!deconvolve, "Must not deconvolve if providing DAC'ified data.");
       int[] arr = vals.getIntArray();
@@ -693,10 +706,13 @@ public class QubitContext extends AbstractServerContext {
           + "Because this represents real data, we only need half as many samples.  "
           + "In particular, for a sequence of length n, the fourier data given "
           + "here must have length n/2+1 (n even) or (n+1)/2 (n odd)."
-          + "If averageEnds is true (the default), then the first and last "
+          + "If averageEnds=true (default: true), then the first and last "
           + "4 nanoseconds of the deconvolved sequence will be averaged and "
           + "set to the same value, to ensure the DAC outputs a constant "
-          + "after the sequence is run.")
+          + "after the sequence is run.  "
+          + "If dither=true (default: false), then the deconvolved data "
+          + "will be dithered by adding random noise to reduce quantization "
+          + "noise (see http://en.wikipedia.org/wiki/Dither).")
   public void sram_analog_fourier_data(
       @Accepts({"s", "ss"}) Data id,
       @Accepts("*c") Data vals,
@@ -711,9 +727,19 @@ public class QubitContext extends AbstractServerContext {
       @Accepts("v[ns]") double t0,
       boolean averageEnds
   ) {
+    sram_analog_fourier_data(id, vals, t0, averageEnds, false);
+  }
+  @SettingOverload
+  public void sram_analog_fourier_data(
+      @Accepts({"s", "ss"}) Data id,
+      @Accepts("*c") Data vals,
+      @Accepts("v[ns]") double t0,
+      boolean averageEnds,
+      boolean dither
+  ) {
     AnalogChannel ch = getChannel(id, AnalogChannel.class);
     ComplexArray c = ComplexArray.fromData(vals);
-    ch.addData(new AnalogDataFourier(c, t0, averageEnds));
+    ch.addData(new AnalogDataFourier(c, t0, averageEnds, dither));
     sramDirty = true;
   }
 

--- a/Qubit Server/dev/src/main/java/org/labrad/qubits/channeldata/AnalogDataFourier.java
+++ b/Qubit Server/dev/src/main/java/org/labrad/qubits/channeldata/AnalogDataFourier.java
@@ -14,11 +14,13 @@ public class AnalogDataFourier extends AnalogDataBase {
 
   private ComplexArray data;
   private double t0;
+  private boolean averageEnds;
   private int[] deconvolvedData;
 
-  public AnalogDataFourier(ComplexArray data, double t0) {
+  public AnalogDataFourier(ComplexArray data, double t0, boolean averageEnds) {
     this.data = data;
     this.t0 = t0;
+    this.averageEnds = averageEnds;
   }
 
   public void checkLength(int expected) {
@@ -29,7 +31,15 @@ public class AnalogDataFourier extends AnalogDataBase {
   @Override
   public Future<Void> deconvolve(DeconvolutionProxy deconvolver) {
     AnalogChannel ch = getChannel();
-    Future<int[]> req = deconvolver.deconvolveAnalogFourier(ch.getDacBoard(), ch.getDacId(), data, t0, ch.getSettlingRates(), ch.getSettlingTimes());
+    Future<int[]> req = deconvolver.deconvolveAnalogFourier(
+        ch.getDacBoard(),
+        ch.getDacId(),
+        data,
+        t0,
+        ch.getSettlingRates(),
+        ch.getSettlingTimes(),
+        averageEnds
+    );
     return Futures.chain(req, new Function<int[], Void>() {
       @Override
       public Void apply(int[] result) {

--- a/Qubit Server/dev/src/main/java/org/labrad/qubits/channeldata/AnalogDataFourier.java
+++ b/Qubit Server/dev/src/main/java/org/labrad/qubits/channeldata/AnalogDataFourier.java
@@ -15,12 +15,14 @@ public class AnalogDataFourier extends AnalogDataBase {
   private ComplexArray data;
   private double t0;
   private boolean averageEnds;
+  private boolean dither;
   private int[] deconvolvedData;
 
-  public AnalogDataFourier(ComplexArray data, double t0, boolean averageEnds) {
+  public AnalogDataFourier(ComplexArray data, double t0, boolean averageEnds, boolean dither) {
     this.data = data;
     this.t0 = t0;
     this.averageEnds = averageEnds;
+    this.dither = dither;
   }
 
   public void checkLength(int expected) {
@@ -38,7 +40,8 @@ public class AnalogDataFourier extends AnalogDataBase {
         t0,
         ch.getSettlingRates(),
         ch.getSettlingTimes(),
-        averageEnds
+        averageEnds,
+        dither
     );
     return Futures.chain(req, new Function<int[], Void>() {
       @Override

--- a/Qubit Server/dev/src/main/java/org/labrad/qubits/channeldata/AnalogDataTime.java
+++ b/Qubit Server/dev/src/main/java/org/labrad/qubits/channeldata/AnalogDataTime.java
@@ -13,11 +13,13 @@ public class AnalogDataTime extends AnalogDataBase {
 
   private double[] rawData = null;
   private boolean averageEnds;
+  private boolean dither;
   private int[] deconvolvedData = null;
 
-  public AnalogDataTime(double[] data, boolean isDeconvolved, boolean averageEnds) {
+  public AnalogDataTime(double[] data, boolean isDeconvolved, boolean averageEnds, boolean dither) {
     this.rawData = data;
     this.averageEnds = averageEnds;
+    this.dither = dither;
     if (isDeconvolved) {
       int[] values = new int[data.length];
       for (int i = 0; i < data.length; i++) {
@@ -51,7 +53,8 @@ public class AnalogDataTime extends AnalogDataBase {
         rawData,
         ch.getSettlingRates(),
         ch.getSettlingTimes(),
-        averageEnds
+        averageEnds,
+        dither
     );
     return Futures.chain(req, new Function<int[], Void>() {
       @Override

--- a/Qubit Server/dev/src/main/java/org/labrad/qubits/channeldata/AnalogDataTime.java
+++ b/Qubit Server/dev/src/main/java/org/labrad/qubits/channeldata/AnalogDataTime.java
@@ -12,10 +12,12 @@ import com.google.common.base.Preconditions;
 public class AnalogDataTime extends AnalogDataBase {
 
   private double[] rawData = null;
+  private boolean averageEnds;
   private int[] deconvolvedData = null;
 
-  public AnalogDataTime(double[] data, boolean isDeconvolved) {
+  public AnalogDataTime(double[] data, boolean isDeconvolved, boolean averageEnds) {
     this.rawData = data;
+    this.averageEnds = averageEnds;
     if (isDeconvolved) {
       int[] values = new int[data.length];
       for (int i = 0; i < data.length; i++) {
@@ -26,10 +28,11 @@ public class AnalogDataTime extends AnalogDataBase {
     setDeconvolved(isDeconvolved);
   }
 
-    public AnalogDataTime(int[] data) {
-      this.deconvolvedData = data;
-      setDeconvolved(true);
-    }
+  public AnalogDataTime(int[] data) {
+    this.deconvolvedData = data;
+    this.averageEnds = false;
+    setDeconvolved(true);
+  }
 
   public void checkLength(int expected) {
     if (rawData == null) {
@@ -42,7 +45,14 @@ public class AnalogDataTime extends AnalogDataBase {
   @Override
   public Future<Void> deconvolve(DeconvolutionProxy deconvolver) {
     AnalogChannel ch = getChannel();
-    Future<int[]> req = deconvolver.deconvolveAnalog(ch.getDacBoard(), ch.getDacId(), rawData, ch.getSettlingRates(), ch.getSettlingTimes());
+    Future<int[]> req = deconvolver.deconvolveAnalog(
+        ch.getDacBoard(),
+        ch.getDacId(),
+        rawData,
+        ch.getSettlingRates(),
+        ch.getSettlingTimes(),
+        averageEnds
+    );
     return Futures.chain(req, new Function<int[], Void>() {
       @Override
       public Void apply(int[] result) {

--- a/Qubit Server/dev/src/main/java/org/labrad/qubits/channeldata/IqDataFourier.java
+++ b/Qubit Server/dev/src/main/java/org/labrad/qubits/channeldata/IqDataFourier.java
@@ -15,11 +15,13 @@ public class IqDataFourier extends IqDataBase {
 
   private ComplexArray data;
   private double t0;
+  private boolean zeroEnds;
   private int[] I, Q;
 
-  public IqDataFourier(ComplexArray data, double t0) {
+  public IqDataFourier(ComplexArray data, double t0, boolean zeroEnds) {
     this.data = data;
     this.t0 = t0;
+    this.zeroEnds = zeroEnds;
   }
 
   public void checkLength(int expected) {
@@ -30,7 +32,7 @@ public class IqDataFourier extends IqDataBase {
   public Future<Void> deconvolve(DeconvolutionProxy deconvolver) {
     IqChannel ch = getChannel();
     double freq = ch.getMicrowaveConfig().getFrequency();
-    Future<DeconvolutionProxy.IqResult> req = deconvolver.deconvolveIqFourier(ch.getDacBoard(), data, freq, t0);
+    Future<DeconvolutionProxy.IqResult> req = deconvolver.deconvolveIqFourier(ch.getDacBoard(), data, freq, t0, zeroEnds);
     return Futures.chain(req, new Function<DeconvolutionProxy.IqResult, Void>() {
       @Override
       public Void apply(IqResult result) {

--- a/Qubit Server/dev/src/main/java/org/labrad/qubits/channeldata/IqDataTime.java
+++ b/Qubit Server/dev/src/main/java/org/labrad/qubits/channeldata/IqDataTime.java
@@ -14,10 +14,12 @@ import com.google.common.base.Preconditions;
 public class IqDataTime extends IqDataBase {
 
   private ComplexArray data;
+  private boolean zeroEnds;
   private int[] I, Q;
 
-  public IqDataTime(ComplexArray data, boolean isDeconvolved) {
+  public IqDataTime(ComplexArray data, boolean isDeconvolved, boolean zeroEnds) {
     this.data = data;
+    this.zeroEnds = zeroEnds;
     if (isDeconvolved) {
       I = new int[data.re.length];
       Q = new int[data.im.length];
@@ -32,6 +34,7 @@ public class IqDataTime extends IqDataBase {
     public IqDataTime(int[] I, int[] Q) {
       this.I = I;
       this.Q = Q;
+      this.zeroEnds = false;
       setDeconvolved(true);
     }
 
@@ -48,7 +51,7 @@ public class IqDataTime extends IqDataBase {
   public Future<Void> deconvolve(DeconvolutionProxy deconvolver) {
     IqChannel ch = getChannel();
     double freq = ch.getMicrowaveConfig().getFrequency();
-    Future<DeconvolutionProxy.IqResult> req = deconvolver.deconvolveIq(ch.getDacBoard(), data, freq);
+    Future<DeconvolutionProxy.IqResult> req = deconvolver.deconvolveIq(ch.getDacBoard(), data, freq, zeroEnds);
     return Futures.chain(req, new Function<DeconvolutionProxy.IqResult, Void>() {
       @Override
       public Void apply(IqResult result) {

--- a/Qubit Server/dev/src/main/java/org/labrad/qubits/channels/AnalogChannel.java
+++ b/Qubit Server/dev/src/main/java/org/labrad/qubits/channels/AnalogChannel.java
@@ -55,7 +55,7 @@ public class AnalogChannel extends SramChannelBase<AnalogData> {
       int len = fpga.getBlockLength(name);
       len = len % 2 == 0 ? len/2 + 1 : (len+1) / 2;
       double[] zeros = new double[len];
-      data = new AnalogDataFourier(new ComplexArray(zeros, zeros), 0, true);
+      data = new AnalogDataFourier(new ComplexArray(zeros, zeros), 0, true, false);
       data.setChannel(this);
       blocks.put(name, data);
     }

--- a/Qubit Server/dev/src/main/java/org/labrad/qubits/channels/AnalogChannel.java
+++ b/Qubit Server/dev/src/main/java/org/labrad/qubits/channels/AnalogChannel.java
@@ -55,7 +55,7 @@ public class AnalogChannel extends SramChannelBase<AnalogData> {
       int len = fpga.getBlockLength(name);
       len = len % 2 == 0 ? len/2 + 1 : (len+1) / 2;
       double[] zeros = new double[len];
-      data = new AnalogDataFourier(new ComplexArray(zeros, zeros), 0);
+      data = new AnalogDataFourier(new ComplexArray(zeros, zeros), 0, true);
       data.setChannel(this);
       blocks.put(name, data);
     }

--- a/Qubit Server/dev/src/main/java/org/labrad/qubits/channels/IqChannel.java
+++ b/Qubit Server/dev/src/main/java/org/labrad/qubits/channels/IqChannel.java
@@ -26,7 +26,7 @@ public class IqChannel extends SramChannelBase<IqData> {
   public void setFpgaModel(FpgaModel fpga) {
     Preconditions.checkArgument(fpga instanceof FpgaModelMicrowave,
         "IqChannel '%s' requires microwave board.", getName());
-    FpgaModelMicrowave fpgaMicrowave = (FpgaModelMicrowave)fpga; 
+    FpgaModelMicrowave fpgaMicrowave = (FpgaModelMicrowave)fpga;
     this.fpga = fpgaMicrowave;
     fpgaMicrowave.setIqChannel(this);
   }
@@ -56,7 +56,7 @@ public class IqChannel extends SramChannelBase<IqData> {
       // create a dummy data set with zeros
       int expected = fpga.getBlockLength(name);
       double[] zeros = new double[expected];
-      data = new IqDataFourier(new ComplexArray(zeros, zeros), 0);
+      data = new IqDataFourier(new ComplexArray(zeros, zeros), 0, true);
       data.setChannel(this);
       blocks.put(name, data);
     }

--- a/Qubit Server/dev/src/main/java/org/labrad/qubits/proxies/DeconvolutionProxy.java
+++ b/Qubit Server/dev/src/main/java/org/labrad/qubits/proxies/DeconvolutionProxy.java
@@ -44,12 +44,13 @@ public class DeconvolutionProxy {
    * @return
    */
   public Future<int[]> deconvolveAnalog(DacBoard board, DacAnalogId id, double[] data,
-      double[] settlingRates, double[] settlingTimes, boolean averageEnds) {
+      double[] settlingRates, double[] settlingTimes, boolean averageEnds, boolean dither) {
     Request req = startRequest();
     req.add("Board", Data.valueOf(board.getName()));
     req.add("DAC", Data.valueOf(id.toString()));
     req.add("Set Settling", Data.valueOf(settlingRates), Data.valueOf(settlingTimes));
-    final int idx = req.addRecord("Correct Analog", Data.valueOf(data), Data.valueOf(averageEnds));
+    final int idx = req.addRecord("Correct Analog",
+        Data.valueOf(data), Data.valueOf(averageEnds), Data.valueOf(dither));
     return Futures.chain(cxn.send(req), new Function<List<Data>, int[]>() {
       @Override
       public int[] apply(List<Data> result) {
@@ -69,14 +70,15 @@ public class DeconvolutionProxy {
    * @return
    */
   public Future<int[]> deconvolveAnalogFourier(DacBoard board, DacAnalogId id, ComplexArray data, double t0,
-      double[] settlingRates, double[] settlingTimes, boolean averageEnds) {
+      double[] settlingRates, double[] settlingTimes, boolean averageEnds, boolean dither) {
     Request req = startRequest();
     req.add("Board", Data.valueOf(board.getName()));
     req.add("DAC", Data.valueOf(id.toString()));
     req.add("Loop", Data.valueOf(false));
     req.add("Set Settling", Data.valueOf(settlingRates), Data.valueOf(settlingTimes));
     req.add("Time Offset", Data.valueOf(t0));
-    final int idx = req.addRecord("Correct Analog FT", data.toData(), Data.valueOf(averageEnds));
+    final int idx = req.addRecord("Correct Analog FT",
+        data.toData(), Data.valueOf(averageEnds), Data.valueOf(dither));
     return Futures.chain(cxn.send(req), new Function<List<Data>, int[]>() {
       @Override
       public int[] apply(List<Data> result) {

--- a/Qubit Server/dev/src/main/java/org/labrad/qubits/proxies/DeconvolutionProxy.java
+++ b/Qubit Server/dev/src/main/java/org/labrad/qubits/proxies/DeconvolutionProxy.java
@@ -44,12 +44,12 @@ public class DeconvolutionProxy {
    * @return
    */
   public Future<int[]> deconvolveAnalog(DacBoard board, DacAnalogId id, double[] data,
-      double[] settlingRates, double[] settlingTimes) {
+      double[] settlingRates, double[] settlingTimes, boolean averageEnds) {
     Request req = startRequest();
     req.add("Board", Data.valueOf(board.getName()));
     req.add("DAC", Data.valueOf(id.toString()));
     req.add("Set Settling", Data.valueOf(settlingRates), Data.valueOf(settlingTimes));
-    final int idx = req.addRecord("Correct", Data.valueOf(data));
+    final int idx = req.addRecord("Correct Analog", Data.valueOf(data), Data.valueOf(averageEnds));
     return Futures.chain(cxn.send(req), new Function<List<Data>, int[]>() {
       @Override
       public int[] apply(List<Data> result) {
@@ -69,14 +69,14 @@ public class DeconvolutionProxy {
    * @return
    */
   public Future<int[]> deconvolveAnalogFourier(DacBoard board, DacAnalogId id, ComplexArray data, double t0,
-      double[] settlingRates, double[] settlingTimes) {
+      double[] settlingRates, double[] settlingTimes, boolean averageEnds) {
     Request req = startRequest();
     req.add("Board", Data.valueOf(board.getName()));
     req.add("DAC", Data.valueOf(id.toString()));
     req.add("Loop", Data.valueOf(false));
     req.add("Set Settling", Data.valueOf(settlingRates), Data.valueOf(settlingTimes));
     req.add("Time Offset", Data.valueOf(t0));
-    final int idx = req.addRecord("Correct FT", data.toData());
+    final int idx = req.addRecord("Correct Analog FT", data.toData(), Data.valueOf(averageEnds));
     return Futures.chain(cxn.send(req), new Function<List<Data>, int[]>() {
       @Override
       public int[] apply(List<Data> result) {
@@ -103,11 +103,11 @@ public class DeconvolutionProxy {
    * @param settlingTimes
    * @return
    */
-  public Future<IqResult> deconvolveIq(DacBoard board, ComplexArray data, double freq) {
+  public Future<IqResult> deconvolveIq(DacBoard board, ComplexArray data, double freq, boolean averageEnds) {
     Request req = startRequest();
     req.add("Board", Data.valueOf(board.getName()));
     req.add("Frequency", Data.valueOf(freq));
-    final int idx = req.addRecord("Correct", data.toData());
+    final int idx = req.addRecord("Correct IQ", data.toData(), Data.valueOf(averageEnds));
     return Futures.chain(cxn.send(req), new Function<List<Data>, IqResult>() {
       @Override
       public IqResult apply(List<Data> result) {
@@ -127,13 +127,13 @@ public class DeconvolutionProxy {
    * @param settlingTimes
    * @return
    */
-  public Future<IqResult> deconvolveIqFourier(DacBoard board, ComplexArray data, double freq, double t0) {
+  public Future<IqResult> deconvolveIqFourier(DacBoard board, ComplexArray data, double freq, double t0, boolean averageEnds) {
     Request req = startRequest();
     req.add("Board", Data.valueOf(board.getName()));
     req.add("Frequency", Data.valueOf(freq));
     req.add("Loop", Data.valueOf(false));
     req.add("Time Offset", Data.valueOf(t0));
-    final int idx = req.addRecord("Correct FT", data.toData());
+    final int idx = req.addRecord("Correct IQ FT", data.toData(), Data.valueOf(averageEnds));
     return Futures.chain(cxn.send(req), new Function<List<Data>, IqResult>() {
       @Override
       public IqResult apply(List<Data> result) {

--- a/dac_calibration_server.py
+++ b/dac_calibration_server.py
@@ -173,12 +173,6 @@ class CalibrationServer(LabradServer):
         c['Board'] = board
         return board
 
-    @setting(2, 'borderValues', borderValues= ['*v'], returns=['*v'])
-    def set_border_values(self, c, borderValues):
-        """Sets the end value to be enforced on the deconvolved output. By default it is zero, for single block. For dual block this must be set"""
-        print "Border values is deprecated, it is always set to average."
-        return borderValues
-
     @setting(10, 'Frequency', frequency=['v[GHz]'], returns=['v[GHz]'])
     def frequency(self, c, frequency):
         """Sets the microwave driving frequency for which to correct the data.

--- a/dac_calibration_server.py
+++ b/dac_calibration_server.py
@@ -251,7 +251,9 @@ class CalibrationServer(LabradServer):
         c['DAC'] = dac
         return dac
 
-    @setting(30, 'Correct IQ', data=['*(v, v): I/Q data', '*c: I/Q data'],
+    @setting(30,
+        'Correct IQ',
+        data=['*(v, v): I/Q data', '*c: I/Q data'],
         zero_ends='b',
         returns=['(*i, *i): Dual channel DAC values'])
     def correct_iq(self, c, data, zero_ends=False):
@@ -277,9 +279,12 @@ class CalibrationServer(LabradServer):
             print 'No deconv on board ' + c['Board'] 
         returnValue(corrected)
 
-    @setting(31, 'Correct Z', data=['*v: Single channel data'],
-        average_ends='b', dither='b',
-        returns=['*i: Single channel DAC values',])
+    @setting(31,
+        'Correct Z',
+        data=['*v: Single channel data'],
+        average_ends='b',
+        dither='b',
+        returns=['*i: Single channel DAC values'])
     def correct_z(self, c, data, average_ends=False, dither=False):
         """Correct single channel data specified in the time domain."""
         # All settings there?
@@ -303,7 +308,9 @@ class CalibrationServer(LabradServer):
             print 'No deconv on board ' + c['Board']
         returnValue(corrected)
 
-    @setting(32, 'Correct IQ FT', data=['*(v, v): I/Q data', '*c: I/Q data'],
+    @setting(32,
+        'Correct IQ FT',
+        data=['*(v, v): I/Q data', '*c: I/Q data'],
         zero_ends='b',
         returns=['(*i, *i): Dual channel DAC values'])
     def correct_iq_ft(self, c, data, zero_ends=False):
@@ -335,8 +342,11 @@ class CalibrationServer(LabradServer):
             print 'No deconv on board ' + c['Board']
         returnValue(corrected)
 
-    @setting(33, 'Correct Z FT', data=['*v: Single channel data'],
-        average_ends='b', dither='b',
+    @setting(33,
+        'Correct Z FT',
+        data=['*v: Single channel data'],
+        average_ends='b',
+        dither='b',
         returns=['*i: Single channel DAC values'])
     def correct_z_ft(self, c, data, average_ends=False, dither=False):
         """Correct single channel data specified in the frequency domain.

--- a/dac_calibration_server.py
+++ b/dac_calibration_server.py
@@ -240,7 +240,17 @@ class CalibrationServer(LabradServer):
         zero_ends='b',
         returns=['(*i, *i): Dual channel DAC values'])
     def correct_iq(self, c, data, zero_ends=False):
-        """Correct IQ data specified in the time domain."""
+        """Correct IQ data specified in the time domain.
+
+        Args:
+            data (list of tuple or list of complex): The time-domain IQ sequence
+                to be deconvolved.
+            zero_ends (boolean): If true, the first and last 4 nanoseconds will
+                be set to the deconvolved zero value to ensure microwaves are off.
+
+        Returns:
+            A tuple of deconvolved I DAC values and Q DAC values.
+        """
 
         if len(data) == 0:
             returnValue([]) # special case for empty data
@@ -269,6 +279,15 @@ class CalibrationServer(LabradServer):
         """Correct IQ data specified in the frequency domain.
 
         This allows for sub-nanosecond timing resolution.
+
+        Args:
+            data (list of tuple or list of complex): The frequency-domain IQ
+                sequence to be deconvolved.
+            zero_ends (boolean): If true, the first and last 4 nanoseconds will
+                be set to the deconvolved zero value to ensure microwaves are off.
+
+        Returns:
+            A tuple of deconvolved I DAC values and Q DAC values.
         """
         if len(data) == 0:
             returnValue([]) # special case for empty data
@@ -297,8 +316,19 @@ class CalibrationServer(LabradServer):
         dither='b',
         returns=['*i: Single channel DAC values'])
     def correct_analog(self, c, data, average_ends=False, dither=False):
-        """Correct single channel data specified in the time domain."""
+        """Correct single channel data specified in the time domain.
 
+        Args:
+            data (list of float): The time-domain sequence to be deconvolved.
+            average_ends (boolean): If true, the first and last 4 nanoseconds
+                will be averaged and set to the constant average value to
+                ensure the DAC output is constant after the sequence ends.
+            dither (boolean): If true, the sequence will be dithered by adding
+                random noise to reduce quantization noise.
+
+        Returns:
+            A list of deconvolved DAC values.
+        """
         if len(data) == 0:
             returnValue([]) # special case for empty data
 
@@ -325,6 +355,17 @@ class CalibrationServer(LabradServer):
         """Correct single channel data specified in the frequency domain.
 
         This allows for sub-nanosecond timing resolution.
+
+        Args:
+            data (list of float): The frequency-domain sequence to be deconvolved.
+            average_ends (boolean): If true, the first and last 4 nanoseconds
+                will be averaged and set to the constant average value to
+                ensure the DAC output is constant after the sequence ends.
+            dither (boolean): If true, the sequence will be dithered by adding
+                random noise to reduce quantization noise.
+
+        Returns:
+            A list of deconvolved DAC values.
         """
         if len(data) == 0:
             returnValue([]) # special case for empty data

--- a/dac_calibration_server.py
+++ b/dac_calibration_server.py
@@ -52,7 +52,7 @@ import labrad
 from labrad.types import Error
 from labrad.server import LabradServer, setting
 
-from ghzdac import IQcorrector, DACcorrector, keys #,loadServerSettings
+from ghzdac import IQcorrector, DACcorrector, keys
 from ghzdac.correction import fastfftlen
 
 
@@ -86,15 +86,12 @@ class CalibrationServer(LabradServer):
         self.IQcalsets = {}
         self.DACcalsets = {}
         print 'loading server settings...',
-        yield self.loadServerSettings()
+        self.loadServerSettings()
         print 'done.'
         yield LabradServer.initServer(self)
 
-    @inlineCallbacks
     def loadServerSettings(self):
         """Load configuration information from the registry."""
-        reg = self.client.registry()
-        yield reg.cd(['', 'Servers', 'DAC Calibration', keys.SERVERSETTINGS], True)
         d = {}
         defaults = {
             'deconvIQ': True,
@@ -102,14 +99,11 @@ class CalibrationServer(LabradServer):
             'bandwidthIQ': 0.4, #original default: 0.4
             'bandwidthZ': 0.13, #original default: 0.13
             'maxfreqZ': 0.45, #optimal parameter: 10% below Nyquist frequency of dac, 0.45
-            'maxvalueZ': 5.0, #optimal parameter: 5.0, from the jitter in 1/H fourier amplitudes
+            'maxvalueZ': 5.0 #optimal parameter: 5.0, from the jitter in 1/H fourier amplitudes
         }
         for key in keys.SERVERSETTINGVALUES:
             default = defaults.get(key, None)
-            keyval = yield reg.get(key, False, default)
-            if not isinstance(keyval, bool):
-                #keyval is a number, in labrad units
-                keyval = keyval
+            keyval = default
             print key, ':', keyval
             d[key] = keyval
         self.serverSettings = d

--- a/ghzdac/keys.py
+++ b/ghzdac/keys.py
@@ -43,5 +43,4 @@ PULSELENGTH = 'pulse length'
 DACDCPULSE = 'dac dc pulse'
 DACACPULSE = 'dac ac pulse'
 HARMONIC = 'Carrier frequency harmonic'
-SERVERSETTINGS = 'Vince'
 SERVERSETTINGVALUES = ['deconvIQ','deconvZ','bandwidthIQ','bandwidthZ','maxfreqZ','maxvalueZ','dither']

--- a/ghzdac/keys.py
+++ b/ghzdac/keys.py
@@ -43,4 +43,12 @@ PULSELENGTH = 'pulse length'
 DACDCPULSE = 'dac dc pulse'
 DACACPULSE = 'dac ac pulse'
 HARMONIC = 'Carrier frequency harmonic'
-SERVERSETTINGVALUES = ['deconvIQ','deconvZ','bandwidthIQ','bandwidthZ','maxfreqZ','maxvalueZ','dither']
+SERVERSETTINGVALUES = [
+    'deconvIQ',
+    'deconvZ',
+    'bandwidthIQ',
+    'bandwidthZ',
+    'maxfreqZ',
+    'maxvalueZ',
+    'dither'
+]


### PR DESCRIPTION
The deconvolution server was mutating the user's waveform data without respect to any parameters passed into `Correct` or `Correct FT`:

* For Z waveforms, dithering had the appearance of being set by a boolean parameter on the context, but was actually being defaulted to `True` at context initialization! It was also optionally set by a global registry key for the entire server. This should be a per-request variable.
* For Z waveforms, averaging the first and last four SRAM samples was done without regard for any input parameters. This meant that there was *no way* to not have your pulse sequence mutated by the server.
* For IQ waveforms, zeroing the first and last four SRAM samples was done without regard for any input parameters. This meant that there was *no way* to not have your pulse sequence mutated by the server.

This is problematic: anyone trying to use the deconvolution server outside of qubit experiments had their waveforms mysteriously mutated. Note that this is *not* just me. Other people are starting to use fpgaTest for bringup and debugging purposes. We need to be mindful of everyone's use cases when modifying our code base. Aside from that, it is not good software design to bake unexpected behavior into the code.

This change makes all of these mutations optional and off by default. This means that the qubit sequencer code needs to be updated to turn these features on.

@pomalley, would you mind doing that on this branch?

@maffoo @ejeffrey @JulianSKelly @rb25 I will not merge these changes until all of you sign off on it. This is an important and complex piece of code. In fact, I propose that we set this (and in the future other) pieces of code such that they are immutable without LGTM from at least three of the people pinged here.
