### PR TITLE
Remove import_parameters setting on data_vault server.

### DIFF
--- a/data_vault.py
+++ b/data_vault.py
@@ -1147,68 +1147,6 @@ class DataVault(LabradServer):
         if len(params):
             return params
 
-
-    @inlineCallbacks
-    def read_pars_int(self, c, ctx, dataset, curdirs, subdirs=None):
-        p = self.client.registry.packet(context=ctx)
-        todo = []
-        for curdir, curcontent in curdirs:
-            if len(curdir) > 0:
-                p.cd(curdir)
-            for key in curcontent[1]:
-                p.get(key, key=(False, tuple(curdir+[key])))
-            if subdirs is not None:
-                if isinstance(subdirs, list):
-                    for folder in curcontent[0]:
-                        if folder in subdirs:
-                            p.cd(folder)
-                            p.dir(key=(True, tuple(curdir+[folder])))
-                            p.cd(1)
-                elif subdirs != 0:
-                    for folder in curcontent[0]:
-                        p.cd(folder)
-                        p.dir(key=(True, tuple(curdir+[folder])))
-                        p.cd(1)                
-            if len(curdir) > 0:
-                p.cd(len(curdir))
-        ans = yield p.send()
-        if isinstance(subdirs, list):
-            subdirs = -1
-        else:
-            if (subdirs is not None) and (subdirs > 0):
-                subdirs -= 1
-        for key in sorted(ans.settings.keys()):
-            item = ans[key]
-            if isinstance(key, tuple):
-                if key[0]:
-                    curdirs = [(list(key[1]), item)]
-                    yield self.read_pars_int(c, ctx, dataset, curdirs, subdirs)
-                else:
-                    dataset.addParameter(' -> '.join(key[1]), item, saveNow=False)
-        
-        
-
-    @setting(125, 'import parameters',
-                  subdirs=[' : Import current directory',
-                           'w: Include this many levels of subdirectories (0=all)',
-                           '*s: Include these subdirectories'],
-                  returns='')
-    def import_parameters(self, c, subdirs=None):
-        """Reads all entries from the current registry directory, optionally
-        including subdirectories, as parameters into the current dataset."""
-        dataset = self.getDataset(c)
-        ctx = self.client.context()
-        p = self.client.registry.packet(context=ctx)
-        p.duplicate_context(c.ID)
-        p.dir()
-        ans = yield p.send()
-        curdirs = [([], ans.dir)]
-        if subdirs == 0:
-            subdirs = -1
-        yield self.read_pars_int(c, ctx, dataset, curdirs, subdirs)
-        dataset.save() # make sure the new parameters get saved
-        
-
     @setting(200, 'add comment', comment=['s'], user=['s'], returns=[''])
     def add_comment(self, c, comment, user='anonymous'):
         """Add a comment to the current dataset."""


### PR DESCRIPTION
This setting imports a bunch of parameters from the registry by using the context of the given request and assuming that the same context has been set up with the registry. This sort of inter-server context synchronization is a bad idea and needs to go away. This setting is not actually being used, instead we usually just set parameters on our own using the registry wrapper, which is a much more sane way to go. Hence, removing this should be low impact.