### PR TITLE
Convert run_sequence result to single numpy array before flattening.

### DIFF
--- a/GHzDACs/ghz_fpga_server.py
+++ b/GHzDACs/ghz_fpga_server.py
@@ -177,7 +177,7 @@ cmdTime_cycles does not properly estimate sram length
 ### BEGIN NODE INFO
 [info]
 name = GHz FPGAs
-version = 4.0.2
+version = 4.0.3
 description = Talks to DAC and ADC boards
 
 [startup]
@@ -1454,6 +1454,8 @@ class FPGAServer(DeviceServer):
                       runner.runMode == 'demodulate' and \
                       runner.dev.devName in timingOrder:
                         c[runner.dev]['ranges'] = runner.ranges
+                if ans is not None:
+                    ans = np.asarray(ans)
                 returnValue(ans)
             except TimeoutError, err:
                 # log attempt to stdout and file


### PR DESCRIPTION
Previously, the result from run_sequence was being returned as a python list of numpy arrays, so that the special flattening code for numpy arrays was being bypassed. With this change, @JulianSKelly and I saw roughly a factor 2x increase in data throughput under load.