### PR TITLE
Change ghz_fpga_server to always read a list of packets.

### DIFF
--- a/GHzDACs/Cleanup/fpga.py
+++ b/GHzDACs/Cleanup/fpga.py
@@ -176,10 +176,10 @@ class FPGA(DeviceWrapper):
         p.write(regs.tostring())
         if readback:
             p.timeout(timeout)
-            p.read()
+            p.read(1)
         ans = yield p.send()
         if readback:
-            src, dst, eth, data = ans.read
+            src, dst, eth, data = ans.read[0]
             returnValue(data)
     
     def _runSerial(self):

--- a/GHzDACs/ghz_fpga_server.py
+++ b/GHzDACs/ghz_fpga_server.py
@@ -401,7 +401,8 @@ class BoardGroup(object):
             found = []
             while (len(found) < len(macs)) and (time.time() - start < timeout):
                 try:
-                    src, dst, eth, data = yield self.server.read(context=ctx)
+                    ans = yield self.server.read(1, context=ctx)
+                    src, dst, eth, data = ans[0]
                     if src in macs:
                         devInfo = callback(src, data)
                         found.append(devInfo)

--- a/GHzDACs/sequencer.py
+++ b/GHzDACs/sequencer.py
@@ -83,9 +83,9 @@ class FPGADevice(DeviceWrapper):
         # do we need to clear waiting packets first?
         p = self.server.packet()
         p.write(words2str(packet))
-        p.read()
+        p.read(1)
         ans = yield p.send(context=self.ctx)
-        src, dst, eth, data = ans.read
+        src, dst, eth, data = ans.read[0]
         if asWords:
             data = [ord(c) for c in data]
         returnValue(data)
@@ -293,8 +293,8 @@ class FPGAServer(DeviceServer):
             # get ID packets from all boards
             for i in xrange(256):
                 try:
-                    ans = yield de.read(context=ctx)
-                    src, dst, eth, data = ans
+                    ans = yield de.read(1, context=ctx)
+                    src, dst, eth, data = ans[0]
                     board, build = int(src[-2:], 16), ord(data[51])
                     if build != BUILD:
                         continue


### PR DESCRIPTION
The delphi direct ethernet server changes the 'shape' of packet responses when you try to read one versus multiple packets. In particular, if you call `.read()` it returns a single packet as `(ssis)`, but if you call `.read(1)` it returns a list of one packet as `*(ssis)`, which obviously is the same type used for larger numbers of packets as well. By changing all the read calls to specify the number of packets explicitly, we always get the same type back, which normalizes the response handling. In the new scala version of the direct ethernet server, this allows us to simplify the implementation since we can just specify a single return type.