### PR TITLE
Remove exception raised by recoverFromTimeout.

### DIFF
--- a/GHzDACs/ghz_fpga_server.py
+++ b/GHzDACs/ghz_fpga_server.py
@@ -254,7 +254,8 @@ I2C_END = 0x400
 
 class TimeoutError(Exception):
     """Error raised when boards timeout."""
-    
+
+
 class BoardGroup(object):
     """Manages a group of GHz DAC boards that can be run simultaneously.
     
@@ -1474,18 +1475,19 @@ class FPGAServer(DeviceServer):
                 userpath = os.path.expanduser('~')
                 logpath = os.path.join(userpath, 'dac_timeout_log.txt')
                 with open(logpath, 'a') as logfile:
-                    print 'attempt %d - error: %s' % (attempt, err)
-                    print >>logfile, 'attempt %d - error: %s' % (attempt, err)
+                    t = timeString()
+                    msg = '{}: attempt {} - error: {}'.format(t, attempt, err)
+                    print(msg)
+                    logfile.write(msg+'\n')
                     if attempt == retries:
-                        print 'FAIL!'
-                        print >>logfile, 'FAIL!'
+                        logfile.write('FAIL\n')
                         #TODO: notify users via SMS
                         raise
                     else:
-                        print 'retrying...'
-                        print >>logfile, 'retrying...'
+                        print('retrying...')
+                        logfile.write('retrying...')
                         attempt += 1
-    
+
     @setting(52, 'Daisy Chain', boards='*s', returns='*s')
     def sequence_boards(self, c, boards=None):
         """

--- a/GHzDACs/ghz_fpga_server.py
+++ b/GHzDACs/ghz_fpga_server.py
@@ -850,8 +850,8 @@ class BoardGroup(object):
                     )
                 runner.executionCount = count
             except Exception as e:
+                print("Attempt to read execution counts failed: ")
                 print e
-                raise Exception('Recover from error failed')
             # Finally, clear the packet buffer and send trigger if this was a
             # failed board
             finally:


### PR DESCRIPTION
(Making PR so folks can tell me if I'm being high with this strategy)

We explicitly silence exceptions occuring during the board pings. This is ok because we have a finally clause to clear the packet buffers in the direct ethernet server.

Also increase number of retries for timeout errors.

The only thing left to do here (I think) is improve the error logging e.g. by adding time stamps.

Fixes #137.