### PR TITLE
Do not assume case-insensitivity when building registry paths.

### DIFF
--- a/cryo_notifier.py
+++ b/cryo_notifier.py
@@ -122,12 +122,12 @@ class CryoNotifier(LabradServer):
         folder in the registry. '''
         # pull out node names
         nodes = [x for x in self.client.servers if x.lower().startswith('node')]
-        nodes = [x.partition(' ')[2].lower() for x in nodes]
+        nodes = [x.partition(' ')[2] for x in nodes]
         p = self.reg.packet()
         p.cd(self.path)
         p.dir()
         ans = yield p.send()
-        dirs = [x.lower() for x in ans['dir'][0]]
+        dirs = ans['dir'][0]
         matches = [x for x in nodes if x in dirs]
         if not matches:
             print "No node <--> registry directory matches found. Using %s" % self.path

--- a/lakeshore370.py
+++ b/lakeshore370.py
@@ -151,14 +151,10 @@ class RuOxWrapper(GPIBDeviceWrapper):
         yield self.reloadSettleTime(path)
     
     def getRegistryPath(self):
-        """Get a registry path suitable for registry.cd
-        
-        Warning - the registry is controlled by the same program as the manager
-        which runs in Windoze. This means that paths are case insensitive.
-        """
+        """Get a registry path suitable for registry.cd"""
         path = ['', 'Servers', 'Lakeshore 370']
-        gpibServerName, addr = self.name.split(' - ')
-        nodeName = gpibServerName.split(' ')[0].lower()
+        gpibServerName, addr = self.name.split(' - ', 1)
+        nodeName = gpibServerName.split(' ')[0]
         path.extend([nodeName, addr])
         return path
     


### PR DESCRIPTION
When building registry paths in some instance were were lower-casing the directory names and assuming the registry was case-insensitive, which was an artifact of the registry being a thin wrapper around the windows filesystem. In the new delphi implementation, registry paths are case sensitive. We had to make these changes to get the scala manager and registry proxy working on vince, er Vince.