### PR TITLE
Expand "~" and "~username" in data_vault.

### DIFF
--- a/data_vault.py
+++ b/data_vault.py
@@ -88,7 +88,7 @@ class DataVault(LabradServer):
             try:
                 print 'Could not load repository location from registry.'
                 print 'Please enter data storage directory or hit enter to use the current directory:'
-                datadir = raw_input('>>>')
+                datadir = os.path.expanduser(raw_input('>>>'))
                 if datadir == '':
                     datadir = os.path.join(os.path.split(__file__)[0], '__data__')
                 if not os.path.exists(datadir):


### PR DESCRIPTION
Allows the repository location to be specified with ~ and ~username
instead of just the full path. Fixes #144 and maffoo/scalabrad#2.