### PR TITLE
Consolidate code shared by data_vault and data_vault_multihead

### DIFF
--- a/data_vault.py
+++ b/data_vault.py
@@ -30,410 +30,75 @@ timeout = 5
 ### END NODE INFO
 """
 
-# CHANGELOG
-#
-# 31 January 2012 - Dan Sank and Ted White
-# Added setting to dump existing open sessions in Session._sessions.
-# We did this because the data vault seems to be leaking memory.
-# We think sessions are never getting garbage collected
-# even after all listening contexts expire. We want to be able to view all
-# existing sessions to see if this is causing the memory leak.
-
-from __future__ import with_statement
+from __future__ import absolute_import
 
 import os
 import sys
 
-from twisted.internet.defer import inlineCallbacks
+from twisted.internet import reactor
+from twisted.internet.defer import inlineCallbacks, returnValue
 
-from labrad.server import LabradServer, Signal, setting
 import labrad.util
+import labrad.wrappers
 
-import datavault as dv
-from datavault import errors
-
-
-# TODO: tagging
-# - search globally (or in some subtree of sessions) for matching tags
-#     - this is the least common case, and will be an expensive operation
-#     - don't worry too much about optimizing this
-#     - since we won't bother optimizing the global search case, we can store
-#       tag information in the session
+from datavault import SessionStore
+from datavault.server import DataVault
 
 
-class DataVault(LabradServer):
-    name = 'Data Vault'
+@inlineCallbacks
+def load_settings(cxn, name):
+    """Load settings from registry with fallback to command line if needed.
 
+    Attempts to load the data vault configuration for this node from the
+    registry. If not configured, we instead prompt the user to enter a path
+    to use for storing data, and save this config into the registry to be
+    used later.
+    """
+    path = ['', 'Servers', name, 'Repository']
+    nodename = labrad.util.getNodeName()
+    reg = cxn.registry
+    yield reg.cd(path, True)
+    (dirs, keys) = yield reg.dir()
+    if nodename in keys:
+        datadir = yield reg.get(nodename)
+    elif '__default__' in keys:
+        datadir = yield reg.get('__default__')
+    else:
+        default_datadir = os.path.expanduser('~/.labrad/vault')
+        print 'Could not load repository location from registry.'
+        print 'Please enter data storage directory or hit enter to use'
+        print 'the default directory ({}):'.format(default_datadir)
+        datadir = os.path.expanduser(raw_input('>>>'))
+        if datadir == '':
+            datadir = default_datadir
+        if not os.path.exists(datadir):
+            os.makedirs(datadir)
+        # set as default and for this node
+        yield reg.set(nodename, datadir)
+        yield reg.set('__default__', datadir)
+        print 'Data location configured in the registry at {}: {}'.format(
+            path + [nodename], datadir)
+        print 'To change this, edit the registry keys and restart the server.'
+    returnValue(datadir)
+
+def main(argv=sys.argv):
     @inlineCallbacks
-    def initServer(self):
-        # load configuration info from registry
-        try:
-            path = ['', 'Servers', self.name, 'Repository']
-            nodename = labrad.util.getNodeName()
-            reg = self.client.registry
-            try:
-                # try to load for this node
-                p = reg.packet()
-                p.cd(path)
-                p.get(nodename, 's')
-                ans = yield p.send()
-            except:
-                # try to load default
-                p = reg.packet()
-                p.cd(path)
-                p.get('__default__', 's')
-                ans = yield p.send()
-            datadir = ans.get
-        except:
-            try:
-                print 'Could not load repository location from registry.'
-                print 'Please enter data storage directory or hit enter to use the current directory:'
-                datadir = os.path.expanduser(raw_input('>>>'))
-                if datadir == '':
-                    datadir = os.path.join(os.path.split(__file__)[0], '__data__')
-                if not os.path.exists(datadir):
-                    os.makedirs(datadir)
-                # set as default and for this node
-                p = reg.packet()
-                p.cd(path, True)
-                p.set(nodename, datadir)
-                p.set('__default__', datadir)
-                yield p.send()
-                print datadir, "has been saved in the registry",
-                print "as the data location."
-                print "To change this, stop this server,"
-                print "edit the registry keys at", path,
-                print "and then restart."
-            except Exception, E:
-                print
-                print E
-                print
-                print "Press [Enter] to continue..."
-                raw_input()
-                sys.exit()
-        self.session_store = dv.SessionStore(datadir, self)
-        # create root session
-        _root = self.session_store.get([''])
+    def start():
+        opts = labrad.util.parseServerOptions(name=DataVault.name)
+        cxn = yield labrad.wrappers.connectAsync(
+            host=opts['host'], port=int(opts['port']), password=opts['password'])
+        datadir = yield load_settings(cxn, opts['name'])
+        yield cxn.disconnect()
+        session_store = SessionStore(datadir, hub=None)
+        server = DataVault(session_store)
+        session_store.hub = server
 
-    def initContext(self, c):
-        # start in the root session
-        c['path'] = ['']
-        # start listening to the root session
-        c['session'] = self.session_store.get([''])
-        c['session'].listeners.add(c.ID)
+        # Run the server. We do not need to start the reactor, but we will
+        # stop it after the data_vault shuts down.
+        labrad.util.runServer(server, run_reactor=False, stop_reactor=True)
 
-    def expireContext(self, c):
-        """Stop sending any signals to this context."""
-        def removeFromList(ls):
-            if c.ID in ls:
-                ls.remove(c.ID)
-        for session in self.session_store.get_all():
-            removeFromList(session.listeners)
-            for dataset in session.datasets.values():
-                removeFromList(dataset.listeners)
-                removeFromList(dataset.param_listeners)
-                removeFromList(dataset.comment_listeners)
-
-    def getSession(self, c):
-        """Get a session object for the current path."""
-        return c['session']
-
-    def getDataset(self, c):
-        """Get a dataset object for the current dataset."""
-        if 'dataset' not in c:
-            raise errors.NoDatasetError()
-        return c['datasetObj']
-
-    # session signals
-    onNewDir = Signal(543617, 'signal: new dir', 's')
-    onNewDataset = Signal(543618, 'signal: new dataset', 's')
-    onTagsUpdated = Signal(543622, 'signal: tags updated', '*(s*s)*(s*s)')
-
-    # dataset signals
-    onDataAvailable = Signal(543619, 'signal: data available', '')
-    onNewParameter = Signal(543620, 'signal: new parameter', '')
-    onCommentsAvailable = Signal(543621, 'signal: comments available', '')
-
-
-    @setting(5, returns=['*s'])
-    def dump_existing_sessions(self, c):
-        sessions = []
-        for session in self.session_store.geta_all():
-            sessionString=''
-            for s in session.path:
-                sessionString += s+'/'
-            sessions.append(sessionString)
-        return sessions
-
-    @setting(6, tagFilters=['s', '*s'], includeTags='b',
-                returns=['*s{subdirs}, *s{datasets}',
-                         '*(s*s){subdirs}, *(s*s){datasets}'])
-    def dir(self, c, tagFilters=['-trash'], includeTags=False):
-        """Get subdirectories and datasets in the current directory."""
-        #print 'dir:', tagFilters, includeTags
-        if isinstance(tagFilters, str):
-            tagFilters = [tagFilters]
-        sess = self.getSession(c)
-        dirs, datasets = sess.listContents(tagFilters)
-        if includeTags:
-            dirs, datasets = sess.getTags(dirs, datasets)
-        #print dirs, datasets
-        return dirs, datasets
-
-    @setting(7, path=['{get current directory}',
-                      's{change into this directory}',
-                      '*s{change into each directory in sequence}',
-                      'w{go up by this many directories}'],
-                create='b',
-                returns='*s')
-    def cd(self, c, path=None, create=False):
-        """Change the current directory.
-
-        The empty string '' refers to the root directory. If the 'create' flag
-        is set to true, new directories will be created as needed.
-        Returns the path to the new current directory.
-        """
-        if path is None:
-            return c['path']
-
-        temp = c['path'][:] # copy the current path
-        if isinstance(path, (int, long)):
-            if path > 0:
-                temp = temp[:-path]
-                if not len(temp):
-                    temp = ['']
-        else:
-            if isinstance(path, str):
-                path = [path]
-            for segment in path:
-                if segment == '':
-                    temp = ['']
-                else:
-                    temp.append(segment)
-                if not self.session_store.exists(temp) and not create:
-                    raise errors.DirectoryNotFoundError(temp)
-                _session = self.session_store.get(temp) # touch the session
-        if c['path'] != temp:
-            # stop listening to old session and start listening to new session
-            c['session'].listeners.remove(c.ID)
-            session = self.session_store.get(temp)
-            session.listeners.add(c.ID)
-            c['session'] = session
-            c['path'] = temp
-        return c['path']
-
-    @setting(8, name='s', returns='*s')
-    def mkdir(self, c, name):
-        """Make a new sub-directory in the current directory.
-
-        The current directory remains selected.  You must use the
-        'cd' command to select the newly-created directory.
-        Directory name cannot be empty.  Returns the path to the
-        created directory.
-        """
-        if name == '':
-            raise errors.EmptyNameError()
-        path = c['path'] + [name]
-        if self.session_store.exists(path):
-            raise errors.DirectoryExistsError(path)
-        _sess = self.session_store.get(path) # make the new directory
-        return path
-
-    @setting(9, name='s',
-                independents=['*s', '*(ss)'],
-                dependents=['*s', '*(sss)'],
-                returns='(*s{path}, s{name})')
-    def new(self, c, name, independents, dependents):
-        """Create a new Dataset.
-
-        Independent and dependent variables can be specified either
-        as clusters of strings, or as single strings.  Independent
-        variables have the form (label, units) or 'label [units]'.
-        Dependent variables have the form (label, legend, units)
-        or 'label (legend) [units]'.  Label is meant to be an
-        axis label that can be shared among traces, while legend is
-        a legend entry that should be unique for each trace.
-        Returns the path and name for this dataset.
-        """
-        session = self.getSession(c)
-        dataset = session.newDataset(name or 'untitled', independents, dependents)
-        c['dataset'] = dataset.name # not the same as name; has number prefixed
-        c['datasetObj'] = dataset
-        c['filepos'] = 0 # start at the beginning
-        c['commentpos'] = 0
-        c['writing'] = True
-        return c['path'], c['dataset']
-
-    @setting(10, name=['s', 'w'], returns='(*s{path}, s{name})')
-    def open(self, c, name):
-        """Open a Dataset for reading.
-
-        You can specify the dataset by name or number.
-        Returns the path and name for this dataset.
-        """
-        session = self.getSession(c)
-        dataset = session.openDataset(name)
-        c['dataset'] = dataset.name # not the same as name; has number prefixed
-        c['datasetObj'] = dataset
-        c['filepos'] = 0
-        c['commentpos'] = 0
-        c['writing'] = False
-        dataset.keepStreaming(c.ID, 0)
-        dataset.keepStreamingComments(c.ID, 0)
-        return c['path'], c['dataset']
-
-    @setting(20, data=['*v: add one row of data',
-                       '*2v: add multiple rows of data'],
-                 returns='')
-    def add(self, c, data):
-        """Add data to the current dataset.
-
-        The number of elements in each row of data must be equal
-        to the total number of variables in the data set
-        (independents + dependents).
-        """
-        dataset = self.getDataset(c)
-        #Check for unfavored persons, and make them wait
-        # if 'Matteo' in dataset.session:
-            # start = time.time()
-            # while time.time()-start<3:
-                # yield
-        if not c['writing']:
-            raise errors.ReadOnlyError()
-        dataset.addData(data)
-
-    @setting(21, limit='w', startOver='b', returns='*2v')
-    def get(self, c, limit=None, startOver=False):
-        """Get data from the current dataset.
-
-        Limit is the maximum number of rows of data to return, with
-        the default being to return the whole dataset.  Setting the
-        startOver flag to true will return data starting at the beginning
-        of the dataset.  By default, only new data that has not been seen
-        in this context is returned.
-        """
-        dataset = self.getDataset(c)
-        c['filepos'] = 0 if startOver else c['filepos']
-        data, c['filepos'] = dataset.getData(limit, c['filepos'])
-        dataset.keepStreaming(c.ID, c['filepos'])
-        return data
-
-    @setting(100, returns='(*(ss){independents}, *(sss){dependents})')
-    def variables(self, c):
-        """Get the independent and dependent variables for the current dataset.
-
-        Each independent variable is a cluster of (label, units).
-        Each dependent variable is a cluster of (label, legend, units).
-        Label is meant to be an axis label, which may be shared among several
-        traces, while legend is unique to each trace.
-        """
-        ds = self.getDataset(c)
-        ind = [(i['label'], i['units']) for i in ds.independents]
-        dep = [(d['category'], d['label'], d['units']) for d in ds.dependents]
-        return ind, dep
-
-    @setting(120, returns='*s')
-    def parameters(self, c):
-        """Get a list of parameter names."""
-        dataset = self.getDataset(c)
-        dataset.param_listeners.add(c.ID) # send a message when new parameters are added
-        return [par['label'] for par in dataset.parameters]
-
-    @setting(121, 'add parameter', name='s', returns='')
-    def add_parameter(self, c, name, data):
-        """Add a new parameter to the current dataset."""
-        dataset = self.getDataset(c)
-        dataset.addParameter(name, data)
-
-    @setting(124, 'add parameters', params='?{((s?)(s?)...)}', returns='')
-    def add_parameters(self, c, params):
-        """Add a new parameter to the current dataset."""
-        dataset = self.getDataset(c)
-        dataset.addParameters(params)
-
-
-    @setting(126, 'get name', returns='s')
-    def get_name(self, c):
-        """Get the name of the current dataset."""
-        dataset = self.getDataset(c)
-        name = dataset.name
-        return name
-
-    @setting(122, 'get parameter', name='s')
-    def get_parameter(self, c, name, case_sensitive=True):
-        """Get the value of a parameter."""
-        dataset = self.getDataset(c)
-        return dataset.getParameter(name, case_sensitive)
-
-    @setting(123, 'get parameters')
-    def get_parameters(self, c):
-        """Get all parameters.
-
-        Returns a cluster of (name, value) clusters, one for each parameter.
-        If the set has no parameters, nothing is returned (since empty clusters
-        are not allowed).
-        """
-        dataset = self.getDataset(c)
-        names = [par['label'] for par in dataset.parameters]
-        params = tuple((name, dataset.getParameter(name)) for name in names)
-        dataset.param_listeners.add(c.ID) # send a message when new parameters are added
-        if len(params):
-            return params
-
-    @setting(200, 'add comment', comment=['s'], user=['s'], returns=[''])
-    def add_comment(self, c, comment, user='anonymous'):
-        """Add a comment to the current dataset."""
-        dataset = self.getDataset(c)
-        return dataset.addComment(user, comment)
-
-    @setting(201, 'get comments', limit=['w'], startOver=['b'],
-                                  returns=['*(t, s{user}, s{comment})'])
-    def get_comments(self, c, limit=None, startOver=False):
-        """Get comments for the current dataset."""
-        dataset = self.getDataset(c)
-        c['commentpos'] = 0 if startOver else c['commentpos']
-        comments, c['commentpos'] = dataset.getComments(limit, c['commentpos'])
-        dataset.keepStreamingComments(c.ID, c['commentpos'])
-        return comments
-
-    @setting(300, 'update tags', tags=['s', '*s'],
-                  dirs=['s', '*s'], datasets=['s', '*s'],
-                  returns='')
-    def update_tags(self, c, tags, dirs, datasets=None):
-        """Update the tags for the specified directories and datasets.
-
-        If a tag begins with a minus sign '-' then the tag (everything
-        after the minus sign) will be removed.  If a tag begins with '^'
-        then it will be toggled from its current state for each entry
-        in the list.  Otherwise it will be added.
-
-        The directories and datasets must be in the current directory.
-        """
-        if isinstance(tags, str):
-            tags = [tags]
-        if isinstance(dirs, str):
-            dirs = [dirs]
-        if datasets is None:
-            datasets = [self.getDataset(c)]
-        elif isinstance(datasets, str):
-            datasets = [datasets]
-        sess = self.getSession(c)
-        sess.updateTags(tags, dirs, datasets)
-
-    @setting(301, 'get tags',
-                  dirs=['s', '*s'], datasets=['s', '*s'],
-                  returns='*(s*s)*(s*s)')
-    def get_tags(self, c, dirs, datasets):
-        """Get tags for directories and datasets in the current dir."""
-        sess = self.getSession(c)
-        if isinstance(dirs, str):
-            dirs = [dirs]
-        if isinstance(datasets, str):
-            datasets = [datasets]
-        return sess.getTags(dirs, datasets)
-
-
-__server__ = DataVault()
+    _ = start()
+    reactor.run()
 
 if __name__ == '__main__':
-    labrad.util.runServer(__server__)
+    main()

--- a/data_vault_multihead.py
+++ b/data_vault_multihead.py
@@ -13,6 +13,7 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 """
 ### BEGIN NODE INFO
 [info]
@@ -41,16 +42,13 @@ from twisted.application.service import MultiService
 from twisted.application.internet import TCPClient
 from twisted.internet import reactor
 from twisted.internet.reactor import callLater
-from twisted.internet.defer import inlineCallbacks, returnValue, maybeDeferred
-import twisted.internet.task
+from twisted.internet.defer import inlineCallbacks, returnValue
 
-import labrad
-from labrad import constants, types as T, util
-from labrad.server import LabradServer, Signal, setting
+from labrad import constants, util
 import labrad.wrappers
 
-import datavault as dv
-from datavault import errors
+from datavault import SessionStore
+from datavault.server import DataVaultMultiHead
 
 def lock_path(d):
     '''
@@ -84,440 +82,8 @@ def unlock(fd):
     import fcntl
     fcntl.flock(fd, fcntl.LOCK_UN)
 
-class ExtendedContext(object):
-    '''
-    This is an extended context that contains the manager.  This prevents multiple
-    contexts with the same client ID from conflicting if they are connected
-    to different managers.
-    '''
-    def __init__(self, server, ctx):
-        self.__server = server
-        self.__ctx = ctx
 
-    @property
-    def server(self):
-        return self.__server
-
-    @property
-    def context(self):
-        return self.__ctx
-
-    def __eq__(self, other):
-        return (self.context == other.context) and (self.server == other.server)
-
-    def __ne__(self, other):
-        return not (self == other)
-
-    def __hash__(self):
-        return hash(self.context) ^ hash(self.server.host) ^ self.server.port
-
-
-# TODO: tagging
-# - search globally (or in some subtree of sessions) for matching tags
-#     - this is the least common case, and will be an expensive operation
-#     - don't worry too much about optimizing this
-#     - since we won't bother optimizing the global search case, we can store
-#       tag information in the session
-
-
-# One instance per manager.  Not persistent, recreated when connection is lost/regained
-class DataVault(LabradServer):
-    name = 'Data Vault'
-
-    def __init__(self, host, port, password, hub, path, session_store):
-        LabradServer.__init__(self)
-        self.host = host
-        self.port = port
-        self.password = password
-        self.hub = hub
-        self.path = path
-        self.session_store = session_store
-        self.alive = False
-
-        # session signals
-        self.onNewDir = Signal(543617, 'signal: new dir', 's')
-        self.onNewDataset = Signal(543618, 'signal: new dataset', 's')
-        self.onTagsUpdated = Signal(543622, 'signal: tags updated', '*(s*s)*(s*s)')
-
-        # dataset signals
-        self.onDataAvailable = Signal(543619, 'signal: data available', '')
-        self.onNewParameter = Signal(543620, 'signal: new parameter', '')
-        self.onCommentsAvailable = Signal(543621, 'signal: comments available', '')
-
-    def initServer(self):
-        # let the DataVaultHost know that we connected
-        self.hub.connect(self)
-        # create root session
-        self.alive = True
-        _root = self.session_store.get([''])
-        self.keepalive_timer = twisted.internet.task.LoopingCall(self.keepalive)
-        self.onShutdown().addBoth(self.end_keepalive)
-        self.keepalive_timer.start(120)
-
-    def end_keepalive(self, *ignored):
-        # stopServer is only called when the whole application shuts down.
-        # We need to manually use the onShutdown() callback
-        self.keepalive_timer.stop()
-
-    @inlineCallbacks
-    def keepalive(self):
-        print "sending keepalive to %s:%d" % (self.host, self.port)
-        p = self.client.manager.packet()
-        p.echo('123')
-        try:
-            yield p.send()
-        except:
-            pass # We don't care about errors, dropped connections will be recognized automatically
-
-    def initContext(self, c):
-        # start in the root session
-        c['path'] = ['']
-        # start listening to the root session
-        c['session'] = self.session_store.get([''])
-        c['session'].listeners.add(ExtendedContext(self, c.ID))
-        #print "Adding %s to listeners for %s" % (c.ID, [''])
-
-    def expireContext(self, c):
-        """Stop sending any signals to this context."""
-        ctx = ExtendedContext(self, c.ID)
-        def removeFromList(ls):
-            if ctx in ls:
-                ls.remove(ctx)
-        for session in self.session_store.get_all():
-            removeFromList(session.listeners)
-            for dataset in session.datasets.values():
-                removeFromList(dataset.listeners)
-                removeFromList(dataset.param_listeners)
-                removeFromList(dataset.comment_listeners)
-
-    def getSession(self, c):
-        """Get a session object for the current path."""
-        return c['session']
-
-    def getDataset(self, c):
-        """Get a dataset object for the current dataset."""
-        if 'dataset' not in c:
-            raise errors.NoDatasetError()
-        return c['datasetObj']
-
-    @setting(6, tagFilters=['s', '*s'], includeTags='b',
-                returns=['*s{subdirs}, *s{datasets}',
-                         '*(s*s){subdirs}, *(s*s){datasets}'])
-    def dir(self, c, tagFilters=['-trash'], includeTags=None):
-        """Get subdirectories and datasets in the current directory."""
-        #print 'dir:', tagFilters, includeTags
-        if isinstance(tagFilters, str):
-            tagFilters = [tagFilters]
-        sess = self.getSession(c)
-        dirs, datasets = sess.listContents(tagFilters)
-        if includeTags:
-            dirs, datasets = sess.getTags(dirs, datasets)
-        #print dirs, datasets
-        return dirs, datasets
-
-    @setting(7, target = ['       : {get current directory}',
-                          's      : {change into this directory}',
-                          '*s     : {change into each directory in sequence}',
-                          'w      : {go up by this many directories}',
-                          '(s, b) : Enter subdirectory "s", creating it as needed if "b"==True', 
-                          '(*s, b): Enter subdirectories "*s", creating it as needed if "b"==True'], 
-                returns='*s')
-    def cd(self, c, target=None):
-        """Change the current directory.
-
-        The empty string '' refers to the root directory. If the 'create' flag
-        is set to true, new directories will be created as needed.
-        Returns the path to the new current directory.
-        """
-        if target is None:
-            return c['path']
-        if isinstance(target, tuple):
-            path, create = target
-        else:
-            path = target
-            create = False
-
-        temp = c['path'][:] # copy the current path
-        if isinstance(path, (int, long)):
-            if path > 0:
-                temp = temp[:-path]
-                if not len(temp):
-                    temp = ['']
-        else:
-            if isinstance(path, str):
-                path = [path]
-            for segment in path:
-                if segment == '':
-                    temp = ['']
-                else:
-                    temp.append(segment)
-                if not self.session_store.exists(temp) and not create:
-                    raise errors.DirectoryNotFoundError(temp)
-                session = self.session_store.get(temp) # touch the session
-        if c['path'] != temp:
-            # stop listening to old session and start listening to new session
-            ctx = ExtendedContext(self, c.ID)
-            #print "removing %s from session %s" % (ctx, c['path'])
-            c['session'].listeners.remove(ctx)
-            session = self.session_store.get(temp)
-            #print "Adding %s to listeners for %s" % (ctx, temp)
-            session.listeners.add(ctx)
-            c['session'] = session
-            c['path'] = temp
-        return c['path']
-
-    @setting(8, name='s', returns='*s')
-    def mkdir(self, c, name):
-        """Make a new sub-directory in the current directory.
-
-        The current directory remains selected.  You must use the
-        'cd' command to select the newly-created directory.
-        Directory name cannot be empty.  Returns the path to the
-        created directory.
-        """
-        if name == '':
-            raise errors.EmptyNameError()
-        path = c['path'] + [name]
-        if self.session_store.exists(path):
-            raise errors.DirectoryExistsError(path)
-        _sess = self.session_store.get(path) # make the new directory
-        return path
-
-    @setting(9, name='s',
-                independents=['*s', '*(ss)'],
-                dependents=['*s', '*(sss)'],
-                returns='(*s{path}, s{name})')
-    def new(self, c, name, independents, dependents):
-        """Create a new Dataset.
-
-        Independent and dependent variables can be specified either
-        as clusters of strings, or as single strings.  Independent
-        variables have the form (label, units) or 'label [units]'.
-        Dependent variables have the form (label, legend, units)
-        or 'label (legend) [units]'.  Label is meant to be an
-        axis label that can be shared among traces, while legend is
-        a legend entry that should be unique for each trace.
-        Returns the path and name for this dataset.
-        """
-        session = self.getSession(c)
-        dataset = session.newDataset(name or 'untitled', independents, dependents)
-        c['dataset'] = dataset.name # not the same as name; has number prefixed
-        c['datasetObj'] = dataset
-        c['filepos'] = 0 # start at the beginning
-        c['commentpos'] = 0
-        c['writing'] = True
-        return c['path'], c['dataset']
-
-    @setting(10, name=['s', 'w'], returns='(*s{path}, s{name})')
-    def open(self, c, name):
-        """Open a Dataset for reading.
-
-        You can specify the dataset by name or number.
-        Returns the path and name for this dataset.
-        """
-        session = self.getSession(c)
-        dataset = session.openDataset(name)
-        c['dataset'] = dataset.name # not the same as name; has number prefixed
-        c['datasetObj'] = dataset
-        c['filepos'] = 0
-        c['commentpos'] = 0
-        c['writing'] = False
-        ctx = ExtendedContext(self, c.ID)
-        dataset.keepStreaming(ctx, 0)
-        dataset.keepStreamingComments(ctx, 0)
-        return c['path'], c['dataset']
-
-    @setting(20, data=['*v: add one row of data',
-                       '*2v: add multiple rows of data'],
-                 returns='')
-    def add(self, c, data):
-        """Add data to the current dataset.
-
-        The number of elements in each row of data must be equal
-        to the total number of variables in the data set
-        (independents + dependents).
-        """
-        dataset = self.getDataset(c)
-        if not c['writing']:
-            raise errors.ReadOnlyError()
-        dataset.addData(data)
-
-    @setting(21, limit='w', startOver='b', returns='*2v')
-    def get(self, c, limit=None, startOver=False):
-        """Get data from the current dataset.
-
-        Limit is the maximum number of rows of data to return, with
-        the default being to return the whole dataset.  Setting the
-        startOver flag to true will return data starting at the beginning
-        of the dataset.  By default, only new data that has not been seen
-        in this context is returned.
-        """
-        dataset = self.getDataset(c)
-        c['filepos'] = 0 if startOver else c['filepos']
-        data, c['filepos'] = dataset.getData(limit, c['filepos'])
-        ctx = ExtendedContext(self, c.ID)
-        dataset.keepStreaming(ctx, c['filepos'])
-        return data
-
-    @setting(100, returns='(*(ss){independents}, *(sss){dependents})')
-    def variables(self, c):
-        """Get the independent and dependent variables for the current dataset.
-
-        Each independent variable is a cluster of (label, units).
-        Each dependent variable is a cluster of (label, legend, units).
-        Label is meant to be an axis label, which may be shared among several
-        traces, while legend is unique to each trace.
-        """
-        ds = self.getDataset(c)
-        ind = [(i['label'], i['units']) for i in ds.independents]
-        dep = [(d['category'], d['label'], d['units']) for d in ds.dependents]
-        return ind, dep
-
-    @setting(120, returns='*s')
-    def parameters(self, c):
-        """Get a list of parameter names."""
-        dataset = self.getDataset(c)
-        ctx = ExtendedContext(self, c.ID)
-        dataset.param_listeners.add(ctx) # send a message when new parameters are added
-        return [par['label'] for par in dataset.parameters]
-
-    @setting(121, 'add parameter', name='s', returns='')
-    def add_parameter(self, c, name, data):
-        """Add a new parameter to the current dataset."""
-        dataset = self.getDataset(c)
-        dataset.addParameter(name, data)
-
-    @setting(122, 'get parameter', name='s')
-    def get_parameter(self, c, name, case_sensitive=True):
-        """Get the value of a parameter."""
-        dataset = self.getDataset(c)
-        return dataset.getParameter(name, case_sensitive)
-
-    @setting(123, 'get parameters')
-    def get_parameters(self, c):
-        """Get all parameters.
-
-        Returns a cluster of (name, value) clusters, one for each parameter.
-        If the set has no parameters, nothing is returned (since empty clusters
-        are not allowed).
-        """
-        dataset = self.getDataset(c)
-        names = [par['label'] for par in dataset.parameters]
-        params = tuple((name, dataset.getParameter(name)) for name in names)
-        ctx = ExtendedContext(self, c.ID)
-        dataset.param_listeners.add(ctx) # send a message when new parameters are added
-        if len(params):
-            return params
-
-    @setting(124, 'add parameters', params='?{((s?)(s?)...)}', returns='')
-    def add_parameters(self, c, params):
-        """Add a new parameter to the current dataset."""
-        dataset = self.getDataset(c)
-        dataset.addParameters(params)
-
-    @setting(126, 'get name', returns='s')
-    def get_name(self, c):
-        """Get the name of the current dataset."""
-        dataset = self.getDataset(c)
-        name = dataset.name
-        return name
-
-    @setting(200, 'add comment', comment='s', user='s', returns='')
-    def add_comment(self, c, comment, user='anonymous'):
-        """Add a comment to the current dataset."""
-        dataset = self.getDataset(c)
-        return dataset.addComment(user, comment)
-
-    @setting(201, 'get comments', limit='w', startOver='b',
-                                  returns='*(t, s{user}, s{comment})')
-    def get_comments(self, c, limit=None, startOver=False):
-        """Get comments for the current dataset."""
-        dataset = self.getDataset(c)
-        c['commentpos'] = 0 if startOver else c['commentpos']
-        comments, c['commentpos'] = dataset.getComments(limit, c['commentpos'])
-        ctx = ExtendedContext(self, c.ID)
-        dataset.keepStreamingComments(ctx, c['commentpos'])
-        return comments
-
-    @setting(300, 'update tags', tags=['s', '*s'],
-                  dirs=['s', '*s'], datasets=['s', '*s'],
-                  returns='')
-    def update_tags(self, c, tags, dirs, datasets=None):
-        """Update the tags for the specified directories and datasets.
-
-        If a tag begins with a minus sign '-' then the tag (everything
-        after the minus sign) will be removed.  If a tag begins with '^'
-        then it will be toggled from its current state for each entry
-        in the list.  Otherwise it will be added.
-
-        The directories and datasets must be in the current directory.
-        """
-        if isinstance(tags, str):
-            tags = [tags]
-        if isinstance(dirs, str):
-            dirs = [dirs]
-        if datasets is None:
-            datasets = [self.getDataset(c)]
-        elif isinstance(datasets, str):
-            datasets = [datasets]
-        sess = self.getSession(c)
-        sess.updateTags(tags, dirs, datasets)
-
-    @setting(301, 'get tags',
-                  dirs=['s', '*s'], datasets=['s', '*s'],
-                  returns='*(s*s)*(s*s)')
-    def get_tags(self, c, dirs, datasets):
-        """Get tags for directories and datasets in the current dir."""
-        sess = self.getSession(c)
-        if isinstance(dirs, str):
-            dirs = [dirs]
-        if isinstance(datasets, str):
-            datasets = [datasets]
-        return sess.getTags(dirs, datasets)
-
-    @setting(401, 'get servers', returns='*(swb)')
-    def get_servers(self, c):
-        """
-        Returns the list of running servers as tuples of (host, port, connected?)
-        """
-        rv = []
-        for s in self.hub:
-            host = s.host
-            port = s.port
-            running = hasattr(s, 'server') and bool(s.server.alive)
-            print "host: %s port: %s running: %s" % (host, port, running)
-            rv.append((host, port, running))
-        return rv
-
-    @setting(402, 'add server', host=['s'], port=['w'], password=['s'])
-    def add_server(self, c, host, port=0, password=None):
-        """
-        Add new server to the list.
-        """
-        port = port or self.port
-        password = password or self.password
-        dvc = DataVaultConnector(host, port, password, self.hub, self.path, self.session_store)
-        dvc.setServiceParent(self.hub)
-        #self.hub.addService(DataVaultConnector(host, port, password, self.hub, self.path))
-
-    @setting(403, 'Ping Managers')
-    def ping_managers(self, c):
-        self.hub.ping()
-
-    @setting(404, 'Kick Managers', host_regex='s', port='w')
-    def kick_managers(self, c, host_regex, port=0):
-        self.hub.kick(host_regex, port)
-
-    @setting(405, 'Reconnect', host_regex='s', port='w')
-    def reconnect(self, c, host_regex, port=0):
-        self.hub.reconnect(host_regex, port)
-
-    @setting(406, 'Refresh Managers')
-    def refresh_managers(self, c):
-        return self.hub.refresh_managers()
-
-
-# One instance per manager, persistant (not recreated when connections are dropped)
+# One instance per manager, persistent (not recreated when connections are dropped)
 class DataVaultConnector(MultiService):
     """Service that connects the Data Vault to a single LabRAD manager
 
@@ -527,13 +93,12 @@ class DataVaultConnector(MultiService):
     """
     reconnectDelay = 10
 
-    def __init__(self, host, port, password, hub, path, session_store):
+    def __init__(self, host, port, password, hub, session_store):
         MultiService.__init__(self)
         self.host = host
         self.port = port
         self.password = password
         self.hub = hub
-        self.path = path
         self.session_store = session_store
         self.die = False
 
@@ -544,7 +109,7 @@ class DataVaultConnector(MultiService):
     def startConnection(self):
         """Attempt to start the data vault and connect to LabRAD."""
         print 'Connecting to %s:%d...' % (self.host, self.port)
-        self.server = DataVault(self.host, self.port, self.password, self.hub, self.path, self.session_store)
+        self.server = DataVaultMultiHead(self.host, self.port, self.password, self.hub, self.session_store)
         self.server.onStartup().addErrback(self._error)
         self.server.onShutdown().addCallbacks(self._disconnected, self._error)
         self.cxn = TCPClient(self.host, self.port, self.server)
@@ -598,13 +163,11 @@ class DataVaultServiceHost(MultiService):
         self.path = path
         self.managers = managers
         self.servers = set()
-        self.session_store = dv.SessionStore(path, self)
+        self.session_store = SessionStore(path, self)
         for signal in self.signals:
             self.wrapSignal(signal)
         for host, port, password in managers:
-            x = DataVaultConnector(host, port, password, self, self.path, self.session_store)
-            x.setServiceParent(self)
-            #self.addService(DataVaultConnector(host, port, password, self, self.path))
+            self.add_server(host, port, password)
 
     def connect(self, server):
         print 'server connected: %s:%d' % (server.host, server.port)
@@ -674,16 +237,18 @@ class DataVaultServiceHost(MultiService):
                 if connector.host == host and connector.port == port:
                     break
             else:
-                dvc = DataVaultConnector(host, port, password, self, self.path, self.session_store)
-                dvc.setServiceParent(self)
-                #self.addService(DataVaultConnector(host, port, password, self, self.path))
+                self.add_server(host, port, password)
 
         cxn.disconnect()
         return
 
+    def add_server(self, host, port, password):
+        dvc = DataVaultConnector(host, port, password, self, self.session_store)
+        dvc.setServiceParent(self)
+
     def __str__(self):
         managers = ['%s:%d' % (connector.host, connector.port) for connector in self]
-        return 'DataVaultServiceHost(%s)' % (managers,) 
+        return 'DataVaultServiceHost(%s)' % (managers,)
 
     def wrapSignal(self, signal):
         print 'wrapping signal:', signal

--- a/datavault/server.py
+++ b/datavault/server.py
@@ -1,0 +1,447 @@
+from __future__ import absolute_import
+
+import collections
+
+from twisted.internet.defer import inlineCallbacks
+import twisted.internet.task
+
+from labrad.server import LabradServer, Signal, setting
+
+from . import errors
+
+
+class DataVault(LabradServer):
+    name = 'Data Vault'
+
+    def __init__(self, session_store):
+        LabradServer.__init__(self)
+
+        self.session_store = session_store
+
+        # session signals
+        self.onNewDir = Signal(543617, 'signal: new dir', 's')
+        self.onNewDataset = Signal(543618, 'signal: new dataset', 's')
+        self.onTagsUpdated = Signal(543622, 'signal: tags updated', '*(s*s)*(s*s)')
+
+        # dataset signals
+        self.onDataAvailable = Signal(543619, 'signal: data available', '')
+        self.onNewParameter = Signal(543620, 'signal: new parameter', '')
+        self.onCommentsAvailable = Signal(543621, 'signal: comments available', '')
+
+    def initServer(self):
+        # create root session
+        _root = self.session_store.get([''])
+
+    def contextKey(self, c):
+        """The key used to identify a given context for notifications"""
+        return c.ID
+
+    def initContext(self, c):
+        # start in the root session
+        c['path'] = ['']
+        # start listening to the root session
+        c['session'] = self.session_store.get([''])
+        c['session'].listeners.add(self.contextKey(c))
+
+    def expireContext(self, c):
+        """Stop sending any signals to this context."""
+        key = self.contextKey(c)
+        def removeFromList(ls):
+            if key in ls:
+                ls.remove(key)
+        for session in self.session_store.get_all():
+            removeFromList(session.listeners)
+            for dataset in session.datasets.values():
+                removeFromList(dataset.listeners)
+                removeFromList(dataset.param_listeners)
+                removeFromList(dataset.comment_listeners)
+
+    def getSession(self, c):
+        """Get a session object for the current path."""
+        return c['session']
+
+    def getDataset(self, c):
+        """Get a dataset object for the current dataset."""
+        if 'dataset' not in c:
+            raise errors.NoDatasetError()
+        return c['datasetObj']
+
+    @setting(5, returns=['*s'])
+    def dump_existing_sessions(self, c):
+        return ['/'.join(session.path)
+                for session in self.session_store.get_all()]
+
+    @setting(6, tagFilters=['s', '*s'], includeTags='b',
+                returns=['*s{subdirs}, *s{datasets}',
+                         '*(s*s){subdirs}, *(s*s){datasets}'])
+    def dir(self, c, tagFilters=['-trash'], includeTags=False):
+        """Get subdirectories and datasets in the current directory."""
+        #print 'dir:', tagFilters, includeTags
+        if isinstance(tagFilters, str):
+            tagFilters = [tagFilters]
+        sess = self.getSession(c)
+        dirs, datasets = sess.listContents(tagFilters)
+        if includeTags:
+            dirs, datasets = sess.getTags(dirs, datasets)
+        #print dirs, datasets
+        return dirs, datasets
+
+    @setting(7, path=['{get current directory}',
+                      's{change into this directory}',
+                      '*s{change into each directory in sequence}',
+                      'w{go up by this many directories}'],
+                create='b',
+                returns='*s')
+    def cd(self, c, path=None, create=False):
+        """Change the current directory.
+
+        The empty string '' refers to the root directory. If the 'create' flag
+        is set to true, new directories will be created as needed.
+        Returns the path to the new current directory.
+        """
+        if path is None:
+            return c['path']
+
+        temp = c['path'][:] # copy the current path
+        if isinstance(path, (int, long)):
+            if path > 0:
+                temp = temp[:-path]
+                if not len(temp):
+                    temp = ['']
+        else:
+            if isinstance(path, str):
+                path = [path]
+            for segment in path:
+                if segment == '':
+                    temp = ['']
+                else:
+                    temp.append(segment)
+                if not self.session_store.exists(temp) and not create:
+                    raise errors.DirectoryNotFoundError(temp)
+                _session = self.session_store.get(temp) # touch the session
+        if c['path'] != temp:
+            # stop listening to old session and start listening to new session
+            key = self.contextKey(c)
+            c['session'].listeners.remove(key)
+            session = self.session_store.get(temp)
+            session.listeners.add(key)
+            c['session'] = session
+            c['path'] = temp
+        return c['path']
+
+    @setting(8, name='s', returns='*s')
+    def mkdir(self, c, name):
+        """Make a new sub-directory in the current directory.
+
+        The current directory remains selected.  You must use the
+        'cd' command to select the newly-created directory.
+        Directory name cannot be empty.  Returns the path to the
+        created directory.
+        """
+        if name == '':
+            raise errors.EmptyNameError()
+        path = c['path'] + [name]
+        if self.session_store.exists(path):
+            raise errors.DirectoryExistsError(path)
+        _sess = self.session_store.get(path) # make the new directory
+        return path
+
+    @setting(9, name='s',
+                independents=['*s', '*(ss)'],
+                dependents=['*s', '*(sss)'],
+                returns='(*s{path}, s{name})')
+    def new(self, c, name, independents, dependents):
+        """Create a new Dataset.
+
+        Independent and dependent variables can be specified either
+        as clusters of strings, or as single strings.  Independent
+        variables have the form (label, units) or 'label [units]'.
+        Dependent variables have the form (label, legend, units)
+        or 'label (legend) [units]'.  Label is meant to be an
+        axis label that can be shared among traces, while legend is
+        a legend entry that should be unique for each trace.
+        Returns the path and name for this dataset.
+        """
+        session = self.getSession(c)
+        dataset = session.newDataset(name or 'untitled', independents, dependents)
+        c['dataset'] = dataset.name # not the same as name; has number prefixed
+        c['datasetObj'] = dataset
+        c['filepos'] = 0 # start at the beginning
+        c['commentpos'] = 0
+        c['writing'] = True
+        return c['path'], c['dataset']
+
+    @setting(10, name=['s', 'w'], returns='(*s{path}, s{name})')
+    def open(self, c, name):
+        """Open a Dataset for reading.
+
+        You can specify the dataset by name or number.
+        Returns the path and name for this dataset.
+        """
+        session = self.getSession(c)
+        dataset = session.openDataset(name)
+        c['dataset'] = dataset.name # not the same as name; has number prefixed
+        c['datasetObj'] = dataset
+        c['filepos'] = 0
+        c['commentpos'] = 0
+        c['writing'] = False
+        key = self.contextKey(c)
+        dataset.keepStreaming(key, 0)
+        dataset.keepStreamingComments(key, 0)
+        return c['path'], c['dataset']
+
+    @setting(20, data=['*v: add one row of data',
+                       '*2v: add multiple rows of data'],
+                 returns='')
+    def add(self, c, data):
+        """Add data to the current dataset.
+
+        The number of elements in each row of data must be equal
+        to the total number of variables in the data set
+        (independents + dependents).
+        """
+        dataset = self.getDataset(c)
+        if not c['writing']:
+            raise errors.ReadOnlyError()
+        dataset.addData(data)
+
+    @setting(21, limit='w', startOver='b', returns='*2v')
+    def get(self, c, limit=None, startOver=False):
+        """Get data from the current dataset.
+
+        Limit is the maximum number of rows of data to return, with
+        the default being to return the whole dataset.  Setting the
+        startOver flag to true will return data starting at the beginning
+        of the dataset.  By default, only new data that has not been seen
+        in this context is returned.
+        """
+        dataset = self.getDataset(c)
+        c['filepos'] = 0 if startOver else c['filepos']
+        data, c['filepos'] = dataset.getData(limit, c['filepos'])
+        key = self.contextKey(c)
+        dataset.keepStreaming(key, c['filepos'])
+        return data
+
+    @setting(100, returns='(*(ss){independents}, *(sss){dependents})')
+    def variables(self, c):
+        """Get the independent and dependent variables for the current dataset.
+
+        Each independent variable is a cluster of (label, units).
+        Each dependent variable is a cluster of (label, legend, units).
+        Label is meant to be an axis label, which may be shared among several
+        traces, while legend is unique to each trace.
+        """
+        ds = self.getDataset(c)
+        ind = [(i['label'], i['units']) for i in ds.independents]
+        dep = [(d['category'], d['label'], d['units']) for d in ds.dependents]
+        return ind, dep
+
+    @setting(120, returns='*s')
+    def parameters(self, c):
+        """Get a list of parameter names."""
+        dataset = self.getDataset(c)
+        key = self.contextKey(c)
+        dataset.param_listeners.add(key) # send a message when new parameters are added
+        return [par['label'] for par in dataset.parameters]
+
+    @setting(121, 'add parameter', name='s', returns='')
+    def add_parameter(self, c, name, data):
+        """Add a new parameter to the current dataset."""
+        dataset = self.getDataset(c)
+        dataset.addParameter(name, data)
+
+    @setting(124, 'add parameters', params='?{((s?)(s?)...)}', returns='')
+    def add_parameters(self, c, params):
+        """Add a new parameter to the current dataset."""
+        dataset = self.getDataset(c)
+        dataset.addParameters(params)
+
+
+    @setting(126, 'get name', returns='s')
+    def get_name(self, c):
+        """Get the name of the current dataset."""
+        dataset = self.getDataset(c)
+        name = dataset.name
+        return name
+
+    @setting(122, 'get parameter', name='s')
+    def get_parameter(self, c, name, case_sensitive=True):
+        """Get the value of a parameter."""
+        dataset = self.getDataset(c)
+        return dataset.getParameter(name, case_sensitive)
+
+    @setting(123, 'get parameters')
+    def get_parameters(self, c):
+        """Get all parameters.
+
+        Returns a cluster of (name, value) clusters, one for each parameter.
+        If the set has no parameters, nothing is returned (since empty clusters
+        are not allowed).
+        """
+        dataset = self.getDataset(c)
+        names = [par['label'] for par in dataset.parameters]
+        params = tuple((name, dataset.getParameter(name)) for name in names)
+        key = self.contextKey(c)
+        dataset.param_listeners.add(key) # send a message when new parameters are added
+        if len(params):
+            return params
+
+    @setting(200, 'add comment', comment=['s'], user=['s'], returns=[''])
+    def add_comment(self, c, comment, user='anonymous'):
+        """Add a comment to the current dataset."""
+        dataset = self.getDataset(c)
+        return dataset.addComment(user, comment)
+
+    @setting(201, 'get comments', limit=['w'], startOver=['b'],
+                                  returns=['*(t, s{user}, s{comment})'])
+    def get_comments(self, c, limit=None, startOver=False):
+        """Get comments for the current dataset."""
+        dataset = self.getDataset(c)
+        c['commentpos'] = 0 if startOver else c['commentpos']
+        comments, c['commentpos'] = dataset.getComments(limit, c['commentpos'])
+        key = self.contextKey(c)
+        dataset.keepStreamingComments(key, c['commentpos'])
+        return comments
+
+    @setting(300, 'update tags', tags=['s', '*s'],
+                  dirs=['s', '*s'], datasets=['s', '*s'],
+                  returns='')
+    def update_tags(self, c, tags, dirs, datasets=None):
+        """Update the tags for the specified directories and datasets.
+
+        If a tag begins with a minus sign '-' then the tag (everything
+        after the minus sign) will be removed.  If a tag begins with '^'
+        then it will be toggled from its current state for each entry
+        in the list.  Otherwise it will be added.
+
+        The directories and datasets must be in the current directory.
+        """
+        if isinstance(tags, str):
+            tags = [tags]
+        if isinstance(dirs, str):
+            dirs = [dirs]
+        if datasets is None:
+            datasets = [self.getDataset(c)]
+        elif isinstance(datasets, str):
+            datasets = [datasets]
+        sess = self.getSession(c)
+        sess.updateTags(tags, dirs, datasets)
+
+    @setting(301, 'get tags',
+                  dirs=['s', '*s'], datasets=['s', '*s'],
+                  returns='*(s*s)*(s*s)')
+    def get_tags(self, c, dirs, datasets):
+        """Get tags for directories and datasets in the current dir."""
+        sess = self.getSession(c)
+        if isinstance(dirs, str):
+            dirs = [dirs]
+        if isinstance(datasets, str):
+            datasets = [datasets]
+        return sess.getTags(dirs, datasets)
+
+
+class DataVaultMultiHead(DataVault):
+    """Data Vault server with additional settings for running multi-headed.
+
+    One instance will be created for each manager we connect to, and new
+    instances will be created when we reconnect after losing a connection.
+    """
+
+    def __init__(self, host, port, password, hub, session_store):
+        DataVault.__init__(self, session_store)
+        self.host = host
+        self.port = port
+        self.password = password
+        self.hub = hub
+        self.alive = False
+
+    def initServer(self):
+        DataVault.initServer(self)
+        # let the DataVaultHost know that we connected
+        self.hub.connect(self)
+        self.alive = True
+        self.keepalive_timer = twisted.internet.task.LoopingCall(self.keepalive)
+        self.onShutdown().addBoth(self.end_keepalive)
+        self.keepalive_timer.start(120)
+
+    def end_keepalive(self, *ignored):
+        # stopServer is only called when the whole application shuts down.
+        # We need to manually use the onShutdown() callback
+        self.keepalive_timer.stop()
+
+    @inlineCallbacks
+    def keepalive(self):
+        print "sending keepalive to {}:{}".format(self.host, self.port)
+        try:
+            yield self.client.manager.echo('ping')
+        except:
+            pass # We don't care about errors, dropped connections will be recognized automatically
+
+    def contextKey(self, c):
+        return ExtendedContext(self, c.ID)
+
+    @setting(401, 'get servers', returns='*(swb)')
+    def get_servers(self, c):
+        """
+        Returns the list of running servers as tuples of (host, port, connected?)
+        """
+        rv = []
+        for s in self.hub:
+            host = s.host
+            port = s.port
+            running = hasattr(s, 'server') and bool(s.server.alive)
+            print "host: %s port: %s running: %s" % (host, port, running)
+            rv.append((host, port, running))
+        return rv
+
+    @setting(402, 'add server', host='s', port='w', password='s')
+    def add_server(self, c, host, port=None, password=None):
+        """
+        Add new server to the list.
+        """
+        port = port if port is not None else self.port
+        password = password if password is not None else self.password
+        self.hub.add_server(host, port, password)
+
+    @setting(403, 'Ping Managers')
+    def ping_managers(self, c):
+        self.hub.ping()
+
+    @setting(404, 'Kick Managers', host_regex='s', port='w')
+    def kick_managers(self, c, host_regex, port=0):
+        self.hub.kick(host_regex, port)
+
+    @setting(405, 'Reconnect', host_regex='s', port='w')
+    def reconnect(self, c, host_regex, port=0):
+        self.hub.reconnect(host_regex, port)
+
+    @setting(406, 'Refresh Managers')
+    def refresh_managers(self, c):
+        return self.hub.refresh_managers()
+
+class ExtendedContext(object):
+    '''
+    This is an extended context that contains the manager.  This prevents
+    multiple contexts with the same client ID from conflicting if they are
+    connected to different managers.
+    '''
+    def __init__(self, server, ctx):
+        self.__server = server
+        self.__ctx = ctx
+
+    @property
+    def server(self):
+        return self.__server
+
+    @property
+    def context(self):
+        return self.__ctx
+
+    def __eq__(self, other):
+        return (self.context == other.context) and (self.server == other.server)
+
+    def __ne__(self, other):
+        return not (self == other)
+
+    def __hash__(self):
+        return hash(self.context) ^ hash(self.server.host) ^ self.server.port


### PR DESCRIPTION
We move the code for these servers into the datavault package and make the server class for the multi-headed data vault into a subclass of the single-headed server class, so that the two can share the setting code. The server launch scripts are reduced basically just to shims that load some settings and then launch the server itself.

Depends on martinisgroup/pylabrad#114