### PR TITLE
Keep pcap loop alive even if errors occur.

### DIFF
--- a/DirectEthernet/build.sbt
+++ b/DirectEthernet/build.sbt
@@ -2,7 +2,7 @@ organization := "org.labrad"
 
 name := "DirectEthernet"
 
-version := "1.0.0-M1"
+version := "1.1.0"
 
 scalaVersion := "2.11.6"
 
@@ -11,7 +11,7 @@ resolvers += "maffoo" at "https://dl.bintray.com/maffoo/maven"
 
 libraryDependencies ++= Seq(
   "org.labrad" %% "scalabrad" % "0.2.0-M6",
-  "org.pcap4j" % "pcap4j-core" % "1.4.0"
+  "org.pcap4j" % "pcap4j-core" % "1.5.0"
 )
 
 // testing

--- a/DirectEthernet/src/main/pack/DirectEthernet.ini
+++ b/DirectEthernet/src/main/pack/DirectEthernet.ini
@@ -1,6 +1,6 @@
 [info]
 name = Scala Direct Ethernet
-version = 1.0.0-M1
+version = 1.1.0
 description = Provides low-level access to ethernet interfaces via pcap.
 instancename = %LABRADNODE% Direct Ethernet
 

--- a/DirectEthernet/src/test/scala/org/labrad/ethernet/server/DirectEthernetTest.scala
+++ b/DirectEthernet/src/test/scala/org/labrad/ethernet/server/DirectEthernetTest.scala
@@ -55,8 +55,8 @@ class EthernetServerTest extends FunSuite with Matchers {
           assert(pkts.length == 1)
           pkts.head match {
             case (srcMac, dstMac, etherType, pktData) =>
-              assert(srcMac == src.toString)
-              assert(dstMac == dst.toString)
+              assert(MacAddress.getByName(srcMac) == src)
+              assert(MacAddress.getByName(dstMac) == dst)
               assert(etherType == pktData.length)
               assert(pktData.toSeq == data.toSeq)
           }
@@ -84,8 +84,8 @@ class EthernetServerTest extends FunSuite with Matchers {
           de3.sendTrigger(triggerContext)
 
           val t = await(f, timeout = 1.seconds) // should return very quickly
-          assert(t > 1.99) // total wait should have been about two seconds
-          assert(t < 2.50)
+          assert(t > 1.9) // total wait should have been about two seconds
+          assert(t < 2.5)
 
           // can send triggers in advance
           await(de2.sendTrigger(triggerContext))
@@ -100,8 +100,8 @@ class EthernetServerTest extends FunSuite with Matchers {
           Thread.sleep(1000)
           await(de3.sendTrigger(triggerContext))
           val t3 = await(f3, timeout = 1.seconds)
-          assert(t3 > 0.99) // should have taken about one second
-          assert(t3 < 1.50)
+          assert(t3 > 0.9) // should have taken about one second
+          assert(t3 < 1.5)
         }
       }
     }


### PR DESCRIPTION
Fixes #182 

I think this is probably worth having even if the firewall configuration changes fix the pcap errors. We will want to monitor the logs for any errors that crop up in case this happens frequently, but that's a whole other thing...
