### PR TITLE
Fix profanity in ADR + qubit sequencer servers.

### DIFF
--- a/ADR/ADR.py
+++ b/ADR/ADR.py
@@ -1120,7 +1120,7 @@ class ADRServer(DeviceServer):
     def set_heat_switch(self, c, value):
         """ 
         True opens the heat switch, False closes it.
-        There is no confirmation! Don't fuck up.
+        There is no confirmation! Don't mess up.
         """
         dev = self.selectedDevice(c)
         dev.set_heat_switch(value)

--- a/QubitServer/src/main/java/org/labrad/qubits/QubitServer.java
+++ b/QubitServer/src/main/java/org/labrad/qubits/QubitServer.java
@@ -116,7 +116,7 @@ public class QubitServer extends AbstractServer {
     req.add("cd", Data.valueOf(Constants.WIRING_PATH),
         Data.valueOf(true)); // create the directory if needed
     int idx = req.addRecord("get", Data.valueOf(Constants.WIRING_KEY)); //,
-    // Data.valueOf(Constants.WIRING_TYPE)); // no longer enforcing wiring type ==> cluster fuck!
+    // Data.valueOf(Constants.WIRING_TYPE)); // no longer enforcing wiring type ==> FAIL!
     List<Data> ans;
     try {
       ans = getConnection().sendAndWait(req);


### PR DESCRIPTION
Fix profane language in qubit sequencer and ADR servers. Fixes #207.