### PR TITLE
Remove reference to windows-only getch

### DIFF
--- a/GHzDACs/GHz_DAC_bringup.py
+++ b/GHzDACs/GHz_DAC_bringup.py
@@ -24,9 +24,8 @@ import time
 
 import labrad
 from math import sin, pi
-from msvcrt import getch, kbhit
 
-FPGA_SERVER='ghz_fpgas'
+FPGA_SERVER = 'ghz_fpgas'
 DACS = ['A','B']
 NUM_TRIES = 2
 
@@ -234,13 +233,11 @@ def interactiveBringup(fpga, board):
 
 def getChoice(keys):
     """Get a keypress from the user from the specified keys."""
-    while kbhit():
-        getch()
     r = ''
     while not r or r not in keys:
         r = raw_input().upper()
     return r
-    
+
 def selectFromList(options, title):
     """Get a user-selected option
     


### PR DESCRIPTION
Remove imports from msvcrt. The input code was already using `raw_input` anyway (which requires the user to press enter, so this does not change the behavior, just makes it more cross-platform.