### PR TITLE
Fix ghz_fpgas.dac_bringup return signature for LVDS MSD/MHD

### DIFF
--- a/GHzDACs/ghz_fpga_server.py
+++ b/GHzDACs/ghz_fpga_server.py
@@ -177,7 +177,7 @@ cmdTime_cycles does not properly estimate sram length
 ### BEGIN NODE INFO
 [info]
 name = GHz FPGAs
-version = 5.0.2
+version = 5.0.3
 description = Talks to DAC and ADC boards
 
 [startup]
@@ -2030,7 +2030,7 @@ class FPGAServer(DeviceServer):
              lvdsSD='w',
              signed='b',
              targetFifo='w',
-             returns=('*((ss)(sb)(sw)(sw)(sw)(s(*w*b*b))(sw)(sb)(sb)(si)(sw)'
+             returns=('*((ss)(sb)(si)(si)(sw)(s(*w*b*b))(sw)(sb)(sb)(si)(sw)'
                       '(sw)(sb)(s(ww))(s(ww))(s(ww)))'))
     def dac_bringup(self, c, lvdsOptimize=False, lvdsSD=None, signed=True,
                     targetFifo=None):


### PR DESCRIPTION
The return signature for the LVDS MSD and MHD in dac_bringup was 'w', when these can return -1 if 0 or 2+ MSD/MHD bit flips. Change return signature to 'i'. Note this is correct in dac_lvds.

FYI @maffoo, this should probably also get dealt with in #226.
@afowler, this should hopefully fix your ScanPhases error (or at least lead to a later error).