### PR TITLE
Fix compilation error in DirectEthernet tests.

### DIFF
--- a/DirectEthernet/src/test/scala/org/labrad/ethernet/server/TestUtils.scala
+++ b/DirectEthernet/src/test/scala/org/labrad/ethernet/server/TestUtils.scala
@@ -46,13 +46,11 @@ object TestUtils extends {
 
   def withServer[T](host: String, port: Int, password: Array[Char])(body: => T) = {
     val server = new DirectEthernet
-    val s = ServerConnection(server, host, port, password)
-    s.connect()
-    s.serve()
+    server.start(host, port, password, nameOpt = Some("Test Direct Ethernet"))
     try {
       body
     } finally {
-      try s.triggerShutdown() catch { case _: Throwable => }
+      try server.stop() catch { case _: Throwable => }
     }
   }
 }


### PR DESCRIPTION
Fixes #230 

This at least fixes the test compilation problem. I still see issues with the tests themselves due to, for example, the fact that pcap requires administrator access on some platforms. These tests could thus use some additional work, but I'd like to tackle that as part of a separate issue.