### PR TITLE
Remove unneeded calls to clear() in controller constructors.

### DIFF
--- a/QubitServer/build.sbt
+++ b/QubitServer/build.sbt
@@ -2,7 +2,7 @@ organization := "org.labrad"
 
 name := "QubitServer"
 
-version := "0.6.1"
+version := "0.6.2"
 
 scalaVersion := "2.11.6"
 

--- a/QubitServer/src/main/java/org/labrad/qubits/controller/JumpTableController.scala
+++ b/QubitServer/src/main/java/org/labrad/qubits/controller/JumpTableController.scala
@@ -13,8 +13,6 @@ import org.labrad.qubits.jumptable.JumpTable
 class JumpTableController(fpga: FpgaModelDac) extends FpgaController(fpga) {
   private val jumpTable = new JumpTable()
 
-  clear()
-
   override def hasDualBlockSram(): Boolean = {
     false
   }

--- a/QubitServer/src/main/java/org/labrad/qubits/controller/MemoryController.scala
+++ b/QubitServer/src/main/java/org/labrad/qubits/controller/MemoryController.scala
@@ -12,8 +12,6 @@ import scala.collection.mutable
  */
 class MemoryController(fpga: FpgaModelDac) extends FpgaController(fpga) {
 
-  clear()
-
   private val memory = mutable.Buffer.empty[MemoryCommand]
   private var timerStartCount = 0
   private var timerStopCount = 0

--- a/QubitServer/src/main/pack/QubitServer.ini
+++ b/QubitServer/src/main/pack/QubitServer.ini
@@ -1,6 +1,6 @@
 [info]
 name = Qubit Sequencer
-version = 0.6.1
+version = 0.6.2
 description = 
 
 [startup]


### PR DESCRIPTION
Both these calls are not needed, since the instances in both cases are constructed in a 'cleared' state. The MemoryController call in particular was causing a NullPointerException because the clear call could be made before all fields were initialized.

Fixes #243