### PR TITLE
Use LabradException to avoid verbose tracebacks.

### DIFF
--- a/DirectEthernet/build.sbt
+++ b/DirectEthernet/build.sbt
@@ -2,7 +2,7 @@ organization := "org.labrad"
 
 name := "DirectEthernet"
 
-version := "1.2.1"
+version := "1.2.2"
 
 scalaVersion := "2.11.7"
 javacOptions ++= Seq("-source", "1.7", "-target", "1.7")

--- a/DirectEthernet/src/main/pack/DirectEthernet.ini
+++ b/DirectEthernet/src/main/pack/DirectEthernet.ini
@@ -1,6 +1,6 @@
 [info]
 name = Scala Direct Ethernet
-version = 1.2.1
+version = 1.2.2
 description = Provides low-level access to ethernet interfaces via pcap.
 instancename = %LABRADNODE% Direct Ethernet
 


### PR DESCRIPTION
Fixes #233