### PR TITLE
AC Pulse Cal - Allow for no switch

### DIFF
--- a/ghzdac/calibrate.py
+++ b/ghzdac/calibrate.py
@@ -383,7 +383,7 @@ def calibrateACPulse(cxn, boardname, baselineA, baselineB, use_switch=True):
         Did you change settings on the scope during the measurement?"""
         exit
     #set output to zero
-    fpga.dac_run_sram([baseline]*4)
+    fpga.dac_run_sram([baseline]*20)
     uwaveSource.output(False)
     ds = cxn.data_vault
     ds.cd(['',keys.SESSIONNAME,boardname],True)

--- a/ghzdac/keys.py
+++ b/ghzdac/keys.py
@@ -23,6 +23,7 @@ SCOPEOFFSET = 'Sampling Scope DC offset'
 SCOPESENSITIVITY = 'Sampling Scope sensitivity'
 SWITCHPOSITION = 'Microwave switch position'
 SWITCHNAME = 'Microwave switch name'
+SWITCHUSE = 'Microwave switch use'
 TIMEOFFSET = 'DAC delay for pulse calibration'
 SETUPTYPES = ['no IQ mixer',
               'DAC A -> mixer I, DAC B -> mixer Q',

--- a/ghzdac_cal/GHz_DAC_calibrate.py
+++ b/ghzdac_cal/GHz_DAC_calibrate.py
@@ -76,25 +76,28 @@ def calibrate_dc_pulse(fpga_name, channel, dc_scope):
             raise Exception("invalid scope: {}".format(dc_scope))
 
 
-def zero_fixed_carrier(fpga_name):
+def zero_fixed_carrier(fpga_name, use_switch=True):
     """ Calls ghzdac.calibrate.zeroFixedCarrier, synchronously.
     :param str fpga_name: e.g. "Vince DAC 11"
+    :param bool use_switch: Whether to use microwave switch
     :return list[int]: zeros for A and B
     """
     with labrad.connect() as cxn:
-        return calibrate.zeroFixedCarrier(cxn, fpga_name)
+        return calibrate.zeroFixedCarrier(cxn, fpga_name, use_switch=use_switch)
 
 
-def calibrate_ac_pulse(fpga_name, zero_a, zero_b):
+def calibrate_ac_pulse(fpga_name, zero_a, zero_b, use_switch=True):
     """ Calls ghzdac.calibrate.calibrateACPulse, synchronously.
 
     :param str fpga_name:
     :param int zero_a: Zero for channel A, in DAC units (i.e. 0 < x < 0x1FFF)
     :param int zero_b: channel B
+    :param bool use_switch: Whether to use microwave switch
     :return int: dataset number
     """
     with labrad.connect() as cxn:
-        return calibrate.calibrateACPulse(cxn, fpga_name, zero_a, zero_b)
+        return calibrate.calibrateACPulse(cxn, fpga_name, zero_a, zero_b,
+                                          use_switch=use_switch)
 
 
 def calibrate_pulse(cxn, fpga_name, dc_scope = 'infiniium'):
@@ -120,8 +123,10 @@ def calibrate_pulse(cxn, fpga_name, dc_scope = 'infiniium'):
         board_type = 'dc'
     
     if board_type == 'ac':
-        zero_a, zero_b = zero_fixed_carrier(fpga_name)
-        dataset = calibrate_ac_pulse(fpga_name, zero_a, zero_b)
+        use_switch = reg.get(keys.SWITCHUSE, 'b', True, True)
+        zero_a, zero_b = zero_fixed_carrier(fpga_name, use_switch=use_switch)
+        dataset = calibrate_ac_pulse(fpga_name, zero_a, zero_b,
+                                     use_switch=use_switch)
         reg.set(keys.PULSENAME, [dataset])
     elif board_type == 'dc':
         channel = int(raw_input('Select channel: 0 (DAC A) or 1 (DAC B): '))


### PR DESCRIPTION
The AC Pulse calibration for the DACs assumes the use of a microwave switch. This PR adds a registry key to determine if a switch is present.

In addition, the final reset length was <20ns, the minimum jump table sequence length. This length is increased.