### PR TITLE
Clean up names in qubit server to follow scala conventions

### DIFF
--- a/QubitServer/src/main/scala/org/labrad/qubits/FpgaModel.scala
+++ b/QubitServer/src/main/scala/org/labrad/qubits/FpgaModel.scala
@@ -5,7 +5,7 @@ import org.labrad.qubits.resources.DacBoard
 trait FpgaModel {
 
   def name: String
-  def getDacBoard(): DacBoard
-  def getSequenceLength_us(): Double
-  def getSequenceLengthPostSRAM_us(): Double
+  def dacBoard: DacBoard
+  def sequenceLength_us: Double
+  def sequenceLengthPostSRAM_us: Double
 }

--- a/QubitServer/src/main/scala/org/labrad/qubits/FpgaModelAdc.scala
+++ b/QubitServer/src/main/scala/org/labrad/qubits/FpgaModelAdc.scala
@@ -23,11 +23,11 @@ class FpgaModelAdc(board: AdcBoard, expt: Experiment) extends FpgaModel {
       channels += c
   }
 
-  def getChannel(): AdcChannel = {
-    sys.error("getChannel() called for FpgaModelAdc! Bad!")
+  def channel: AdcChannel = {
+    sys.error("channel called for FpgaModelAdc! Bad!")
   }
 
-  override def getDacBoard(): DacBoard = {
+  override def dacBoard: DacBoard = {
     board
   }
 
@@ -36,24 +36,24 @@ class FpgaModelAdc(board: AdcBoard, expt: Experiment) extends FpgaModel {
   //
   // Start Delay - pomalley 5/4/2011
   //
-  private var startDelay = -1
+  private var _startDelay = -1
 
   def setStartDelay(startDelay: Int): Unit = {
-    this.startDelay = startDelay
+    _startDelay = startDelay
   }
 
-  def getStartDelay(): Int = {
-    this.startDelay
+  def startDelay: Int = {
+    _startDelay
   }
 
-  override def getSequenceLength_us(): Double = {
+  override def sequenceLength_us: Double = {
     var t_us = this.startDelay * START_DELAY_UNIT_NS / 1000.0
     t_us += ACQUISITION_TIME_US
     t_us
   }
 
-  override def getSequenceLengthPostSRAM_us(): Double = {
-    getSequenceLength_us()
+  override def sequenceLengthPostSRAM_us: Double = {
+    sequenceLength_us
   }
 
   def packets: Seq[(String, Data)] = {

--- a/QubitServer/src/main/scala/org/labrad/qubits/FpgaModelAnalog.scala
+++ b/QubitServer/src/main/scala/org/labrad/qubits/FpgaModelAnalog.scala
@@ -7,27 +7,23 @@ import org.labrad.qubits.resources.AnalogBoard
 import scala.collection.mutable
 import scala.concurrent.{ExecutionContext, Future}
 
-class FpgaModelAnalog(analogBoard: AnalogBoard, expt: Experiment) extends FpgaModelDac(analogBoard, expt) {
+class FpgaModelAnalog(val analogBoard: AnalogBoard, expt: Experiment) extends FpgaModelDac(analogBoard, expt) {
 
   private val dacs = mutable.Map.empty[DacAnalogId, AnalogChannel]
-
-  def getAnalogBoard(): AnalogBoard = {
-    analogBoard
-  }
 
   def setAnalogChannel(id: DacAnalogId, ch: AnalogChannel): Unit = {
     dacs(id) = ch
   }
 
-  def getDacChannel(id: DacAnalogId): AnalogChannel = {
+  def dacChannel(id: DacAnalogId): AnalogChannel = {
     dacs(id)
   }
 
   def deconvolveSram(deconvolver: DeconvolutionProxy)(implicit ec: ExecutionContext): Future[Unit] = {
     val deconvolutions = for {
       ch <- dacs.values.toVector
-      blockName <- getBlockNames
-      block = ch.getBlockData(blockName)
+      blockName <- blockNames
+      block = ch.blockData(blockName)
       if !block.isDeconvolved()
     } yield block.deconvolve(deconvolver)
 
@@ -39,10 +35,10 @@ class FpgaModelAnalog(analogBoard: AnalogBoard, expt: Experiment) extends FpgaMo
    * @param block
    * @return
    */
-  override protected def getSramDacBits(block: String): Array[Long] = {
-    val sram = Array.fill[Long](getBlockLength(block)) { 0 }
+  override protected def sramDacBits(block: String): Array[Long] = {
+    val sram = Array.fill[Long](blockLength(block)) { 0 }
     for (id <- dacs.keys) {
-      val vals = dacs(id).getSramData(block)
+      val vals = dacs(id).sramData(block)
       for (i <- vals.indices) {
         sram(i) |= ((vals(i) & 0x3FFF).toLong << id.getShift())
       }

--- a/QubitServer/src/main/scala/org/labrad/qubits/FpgaModelMicrowave.scala
+++ b/QubitServer/src/main/scala/org/labrad/qubits/FpgaModelMicrowave.scala
@@ -14,18 +14,18 @@ class FpgaModelMicrowave(microwaveBoard: MicrowaveBoard, expt: Experiment) exten
     this.iq = iq
   }
 
-  def getIqChannel(): IqChannel = {
+  def iqChannel: IqChannel = {
     iq
   }
 
-  def getMicrowaveSource(): MicrowaveSource = {
-    microwaveBoard.getMicrowaveSource()
+  def microwaveSource: MicrowaveSource = {
+    microwaveBoard.microwaveSource
   }
 
   def deconvolveSram(deconvolver: DeconvolutionProxy)(implicit ec: ExecutionContext): Future[Unit] = {
     val deconvolutions = for {
-      blockName <- getBlockNames()
-      block = iq.getBlockData(blockName)
+      blockName <- blockNames
+      block = iq.blockData(blockName)
       if !block.isDeconvolved
     } yield block.deconvolve(deconvolver)
 
@@ -37,11 +37,11 @@ class FpgaModelMicrowave(microwaveBoard: MicrowaveBoard, expt: Experiment) exten
    * @param block
    * @return
    */
-  override protected def getSramDacBits(block: String): Array[Long] = {
-    val sram = Array.fill[Long](getBlockLength(block)) { 0 }
+  override protected def sramDacBits(block: String): Array[Long] = {
+    val sram = Array.fill[Long](blockLength(block)) { 0 }
     if (iq != null) {
-      val A = iq.getSramDataA(block)
-      val B = iq.getSramDataB(block)
+      val A = iq.sramDataA(block)
+      val B = iq.sramDataB(block)
       for (i <- A.indices) {
         sram(i) |= (A(i) & 0x3FFF).toLong + ((B(i) & 0x3FFF).toLong << 14)
       }

--- a/QubitServer/src/main/scala/org/labrad/qubits/channeldata/AnalogDataBase.scala
+++ b/QubitServer/src/main/scala/org/labrad/qubits/channeldata/AnalogDataBase.scala
@@ -4,16 +4,16 @@ import org.labrad.qubits.channels.AnalogChannel
 
 abstract class AnalogDataBase extends AnalogData {
 
-  private var channel: AnalogChannel = null
+  private var _channel: AnalogChannel = null
 
   @volatile private var _isDeconvolved = false
 
   override def setChannel(channel: AnalogChannel): Unit = {
-    this.channel = channel
+    this._channel = channel
   }
 
   protected def getChannel(): AnalogChannel = {
-    channel
+    _channel
   }
 
   /**

--- a/QubitServer/src/main/scala/org/labrad/qubits/channeldata/AnalogDataFourier.scala
+++ b/QubitServer/src/main/scala/org/labrad/qubits/channeldata/AnalogDataFourier.scala
@@ -17,13 +17,13 @@ class AnalogDataFourier(data: ComplexArray, t0: Double, averageEnds: Boolean, di
     val ch = getChannel()
     val req = deconvolver.deconvolveAnalogFourier(
         ch.dacBoard,
-        ch.getDacId(),
+        ch.dacId,
         data,
         t0,
-        ch.getSettlingRates(),
-        ch.getSettlingTimes(),
-        ch.getReflectionRates(),
-        ch.getReflectionAmplitudes(),
+        ch.settlingRates,
+        ch.settlingTimes,
+        ch.reflectionRates,
+        ch.reflectionAmplitudes,
         averageEnds,
         dither
     )

--- a/QubitServer/src/main/scala/org/labrad/qubits/channeldata/AnalogDataTime.scala
+++ b/QubitServer/src/main/scala/org/labrad/qubits/channeldata/AnalogDataTime.scala
@@ -22,12 +22,12 @@ class AnalogDataTime(data: Array[Double], isDeconvolved: Boolean, averageEnds: B
     val ch = getChannel()
     val req = deconvolver.deconvolveAnalog(
         ch.dacBoard,
-        ch.getDacId(),
+        ch.dacId,
         data,
-        ch.getSettlingRates(),
-        ch.getSettlingTimes(),
-        ch.getReflectionRates(),
-        ch.getReflectionAmplitudes(),
+        ch.settlingRates,
+        ch.settlingTimes,
+        ch.reflectionRates,
+        ch.reflectionAmplitudes,
         averageEnds,
         dither
     )

--- a/QubitServer/src/main/scala/org/labrad/qubits/channeldata/IqDataFourier.scala
+++ b/QubitServer/src/main/scala/org/labrad/qubits/channeldata/IqDataFourier.scala
@@ -17,7 +17,7 @@ class IqDataFourier(data: ComplexArray, t0: Double, zeroEnds: Boolean) extends I
 
   def deconvolve(deconvolver: DeconvolutionProxy)(implicit ec: ExecutionContext): Future[Unit] = {
     val ch = getChannel()
-    val freq = ch.getMicrowaveConfig().frequency
+    val freq = ch.microwaveConfig.frequency
     val req = deconvolver.deconvolveIqFourier(ch.dacBoard, data, freq, t0, zeroEnds)
     req.map { result =>
       I = result.I

--- a/QubitServer/src/main/scala/org/labrad/qubits/channeldata/IqDataTime.scala
+++ b/QubitServer/src/main/scala/org/labrad/qubits/channeldata/IqDataTime.scala
@@ -23,7 +23,7 @@ class IqDataTime(data: ComplexArray, isDeconvolved: Boolean, zeroEnds: Boolean) 
 
   override def deconvolve(deconvolver: DeconvolutionProxy)(implicit ec: ExecutionContext): Future[Unit] = {
     val ch = getChannel()
-    val freq = ch.getMicrowaveConfig().frequency
+    val freq = ch.microwaveConfig.frequency
     val req = deconvolver.deconvolveIq(ch.dacBoard, data, freq, zeroEnds)
     req.map { result =>
       I = result.I

--- a/QubitServer/src/main/scala/org/labrad/qubits/channels/AdcChannel.scala
+++ b/QubitServer/src/main/scala/org/labrad/qubits/channels/AdcChannel.scala
@@ -54,16 +54,8 @@ class AdcChannel(val name: String, val dacBoard: AdcBoard) extends Channel with 
 
   clearConfig()
 
-  override def getExperiment(): Experiment = {
-    expt
-  }
-
-  override def getFpgaModel(): FpgaModelAdc = {
+  override def fpgaModel: FpgaModelAdc = {
     fpga
-  }
-
-  override def setExperiment(expt: Experiment): Unit = {
-    this.expt = expt
   }
 
   override def setFpgaModel(fpga: FpgaModel): Unit = {
@@ -157,7 +149,7 @@ class AdcChannel(val name: String, val dacBoard: AdcBoard) extends Channel with 
         s"Critical phase must be between -PI and PI")
     this.criticalPhase = criticalPhase
   }
-  def getPhases(Is: Array[Int], Qs: Array[Int]): Array[Double] = {
+  def phases(Is: Array[Int], Qs: Array[Int]): Array[Double] = {
     (Is zip Qs).map { case (i, q) =>
       Math.atan2(q + this.offsetQ, i + this.offsetI)
     }
@@ -165,7 +157,7 @@ class AdcChannel(val name: String, val dacBoard: AdcBoard) extends Channel with 
   def interpretPhases(Is: Array[Int], Qs: Array[Int]): Array[Boolean] = {
     require(Is.length == Qs.length, "Is and Qs must be of the same shape!")
     //System.out.println("interpretPhases: channel " + channel + " crit phase: " + criticalPhase[channel]);
-    val phases = getPhases(Is, Qs)
+    val phases = this.phases(Is, Qs)
     if (reverseCriticalPhase) {
       phases.map(_ < criticalPhase)
     } else {
@@ -182,12 +174,12 @@ class AdcChannel(val name: String, val dacBoard: AdcBoard) extends Channel with 
     this.mode = AdcMode.AVERAGE
   }
 
-  override def startDelay(): Int = {
-    this.getFpgaModel().getStartDelay()
+  override def startDelay: Int = {
+    fpgaModel.startDelay
   }
 
   override def setStartDelay(startDelay: Int): Unit = {
-    this.getFpgaModel().setStartDelay(startDelay)
+    fpgaModel.setStartDelay(startDelay)
   }
 
   // these are passthroughs to the config object. in most cases we do have to check that
@@ -259,7 +251,7 @@ class AdcChannel(val name: String, val dacBoard: AdcBoard) extends Channel with 
     this.offsetQ = offsetQ
   }
 
-  def getOffsets(): (Int, Int) = {
+  def offsets: (Int, Int) = {
     (offsetI, offsetQ)
   }
 

--- a/QubitServer/src/main/scala/org/labrad/qubits/channels/Channel.scala
+++ b/QubitServer/src/main/scala/org/labrad/qubits/channels/Channel.scala
@@ -34,7 +34,7 @@ object Channel {
         if (boardName.contains("FastBias")) {
           val board = resources.get[FastBias](boardName)
           val fiberId = DcRackFiberId.fromString(channel)
-          val dacBoard = board.getDacBoard(fiberId)
+          val dacBoard = board.dacBoard(fiberId)
           new FastBiasFpgaChannel(name, dacBoard, fiberId)
         } else {
           val rackCard = boardName.toInt
@@ -66,9 +66,6 @@ object Channel {
  */
 trait Channel {
   def name: String
-
-  def setExperiment(expt: Experiment): Unit
-  def getExperiment(): Experiment
 
   def clearConfig(): Unit
 }

--- a/QubitServer/src/main/scala/org/labrad/qubits/channels/FastBiasChannel.scala
+++ b/QubitServer/src/main/scala/org/labrad/qubits/channels/FastBiasChannel.scala
@@ -5,33 +5,20 @@ import org.labrad.qubits.enums.DacFiberId
 import org.labrad.qubits.enums.DcRackFiberId
 import org.labrad.qubits.resources.FastBias
 
-class FastBiasChannel(val name: String, val fiberId: DcRackFiberId) extends FiberChannel {
+class FastBiasChannel(val name: String, val dcRackFiberId: DcRackFiberId) extends FiberChannel {
 
-  protected var expt: Experiment = null
   protected var fb: FastBias = null
 
   def setFastBias(fb: FastBias): Unit = {
     this.fb = fb
   }
 
-  def getFastBias(): FastBias = {
+  def fastBias: FastBias = {
     fb
   }
 
-  def setExperiment(expt: Experiment): Unit = {
-    this.expt = expt
-  }
-
-  def getExperiment(): Experiment = {
-    expt
-  }
-
-  def getDcFiberId(): DcRackFiberId = {
-    fiberId
-  }
-
-  def getFiberId(): DacFiberId = {
-    fb.getFiber(fiberId)
+  def dacFiberId: DacFiberId = {
+    fb.dacFiber(dcRackFiberId)
   }
 
   def clearConfig(): Unit = {

--- a/QubitServer/src/main/scala/org/labrad/qubits/channels/FastBiasFpgaChannel.scala
+++ b/QubitServer/src/main/scala/org/labrad/qubits/channels/FastBiasFpgaChannel.scala
@@ -20,7 +20,7 @@ class FastBiasFpgaChannel(name: String, val dacBoard: DacBoard, fiberId: DcRackF
     }
   }
 
-  def getFpgaModel(): FpgaModelDac = {
+  def fpgaModel: FpgaModelDac = {
     fpga
   }
 }

--- a/QubitServer/src/main/scala/org/labrad/qubits/channels/FastBiasSerialChannel.scala
+++ b/QubitServer/src/main/scala/org/labrad/qubits/channels/FastBiasSerialChannel.scala
@@ -8,7 +8,7 @@ import org.labrad.qubits.enums.DcRackFiberId
  * Created by pomalley on 3/10/2015.
  * FastBias control via serial
  */
-class FastBiasSerialChannel(name: String, dcRackCard: Int, fiberId: DcRackFiberId) extends FastBiasChannel(name, fiberId) {
+class FastBiasSerialChannel(name: String, dcRackCard: Int, dcRackFiberId: DcRackFiberId) extends FastBiasChannel(name, dcRackFiberId) {
 
   private var voltage: Double = _
   private var configured = false
@@ -20,12 +20,12 @@ class FastBiasSerialChannel(name: String, dcRackCard: Int, fiberId: DcRackFiberI
     configured = true
   }
 
-  def hasSetupPacket(): Boolean = {
+  def hasSetupPacket: Boolean = {
     configured
   }
 
-  def getSetupPacket(): SetupPacket = {
-    require(hasSetupPacket(), s"Cannot get setup packet for channel '$name': it has not been configured.")
+  def setupPacket: SetupPacket = {
+    require(hasSetupPacket, s"Cannot get setup packet for channel '$name': it has not been configured.")
     val (dacNum, rcTimeConstant) = dac.toLowerCase match {
       case "dac0" => (0, 1)
       case "dac1slow" => (1, 1)
@@ -36,14 +36,14 @@ class FastBiasSerialChannel(name: String, dcRackCard: Int, fiberId: DcRackFiberI
       "Select Device" -> Data.NONE,
       "channel_set_voltage" -> Cluster(
         UInt(dcRackCard),
-        Str(getDcFiberId.toString.toUpperCase),
+        Str(dcRackFiberId.toString.toUpperCase),
         UInt(dacNum),
         UInt(rcTimeConstant),
         Value(voltage, "V")
       )
     )
 
-    val state = s"$dcRackCard$getDcFiberId: voltage=$voltage dac=$dac"
+    val state = s"$dcRackCard$dcRackFiberId: voltage=$voltage dac=$dac"
 
     SetupPacket(state, records)
   }

--- a/QubitServer/src/main/scala/org/labrad/qubits/channels/FiberChannel.scala
+++ b/QubitServer/src/main/scala/org/labrad/qubits/channels/FiberChannel.scala
@@ -3,5 +3,5 @@ package org.labrad.qubits.channels
 import org.labrad.qubits.enums.DcRackFiberId
 
 trait FiberChannel extends Channel {
-  val fiberId: DcRackFiberId
+  val dcRackFiberId: DcRackFiberId
 }

--- a/QubitServer/src/main/scala/org/labrad/qubits/channels/FpgaChannel.scala
+++ b/QubitServer/src/main/scala/org/labrad/qubits/channels/FpgaChannel.scala
@@ -12,6 +12,6 @@ trait FpgaChannel extends Channel {
   def dacBoard: DacBoard
 
   def setFpgaModel(fpga: FpgaModel): Unit
-  def getFpgaModel(): FpgaModel
+  def fpgaModel: FpgaModel
 
 }

--- a/QubitServer/src/main/scala/org/labrad/qubits/channels/PreampChannel.scala
+++ b/QubitServer/src/main/scala/org/labrad/qubits/channels/PreampChannel.scala
@@ -8,35 +8,14 @@ import org.labrad.qubits.enums.DcRackFiberId
 import org.labrad.qubits.resources.DacBoard
 import org.labrad.qubits.resources.PreampBoard
 
-class PreampChannel(val name: String, preampBoard: PreampBoard, val fiberId: DcRackFiberId) extends FiberChannel with TimingChannel {
+class PreampChannel(val name: String, val preampBoard: PreampBoard, val dcRackFiberId: DcRackFiberId) extends FiberChannel with TimingChannel {
 
-  val dacBoard = preampBoard.getDacBoard(fiberId)
-  private var expt: Experiment = null
   private var fpga: FpgaModelDac = null
   private var config: PreampConfig = null
   private var switchIntervals: Array[(Long, Long)] = null
 
-  clearConfig()
-
-  def getPreampBoard(): PreampBoard = {
-    preampBoard
-  }
-
-  def getPreampChannel(): DcRackFiberId = {
-    fiberId
-  }
-
-  def setExperiment(expt: Experiment): Unit = {
-    this.expt = expt
-  }
-
-  def getExperiment(): Experiment = {
-    expt
-  }
-
-  def getDacBoard(): DacBoard = {
-    dacBoard
-  }
+  def dacBoard: DacBoard = preampBoard.dacBoard(dcRackFiberId)
+  def preampChannel: DcRackFiberId = dcRackFiberId
 
   def setFpgaModel(fpga: FpgaModel): Unit = {
     fpga match {
@@ -45,16 +24,16 @@ class PreampChannel(val name: String, preampBoard: PreampBoard, val fiberId: DcR
     }
   }
 
-  override def getFpgaModel(): FpgaModelDac = {
+  override def fpgaModel: FpgaModelDac = {
     fpga
   }
 
   def startTimer(): Unit = {
-    fpga.getMemoryController.startTimer()
+    fpga.memoryController.startTimer()
   }
 
   def stopTimer(): Unit = {
-    fpga.getMemoryController.stopTimer()
+    fpga.memoryController.stopTimer()
   }
 
   // configuration
@@ -67,11 +46,11 @@ class PreampChannel(val name: String, preampBoard: PreampBoard, val fiberId: DcR
     config = new PreampConfig(offset, polarity, highPass, lowPass)
   }
 
-  def hasPreampConfig(): Boolean = {
+  def hasPreampConfig: Boolean = {
     config != null
   }
 
-  def getPreampConfig(): PreampConfig = {
+  def preampConfig: PreampConfig = {
     config
   }
 
@@ -108,7 +87,4 @@ class PreampChannel(val name: String, preampBoard: PreampBoard, val fiberId: DcR
     -1
   }
 
-  def getDcFiberId(): DcRackFiberId = {
-    this.getPreampChannel()
-  }
 }

--- a/QubitServer/src/main/scala/org/labrad/qubits/channels/SramChannelBase.scala
+++ b/QubitServer/src/main/scala/org/labrad/qubits/channels/SramChannelBase.scala
@@ -7,18 +7,9 @@ import scala.collection.mutable
 
 abstract class SramChannelBase[T](val name: String, val dacBoard: DacBoard) extends SramChannel {
 
-  private var expt: Experiment = null
   protected var fpga: FpgaModelDac = null
 
-  override def getExperiment(): Experiment = {
-    expt
-  }
-
-  override def setExperiment(expt: Experiment): Unit = {
-    this.expt = expt
-  }
-
-  override def getFpgaModel(): FpgaModelDac = {
+  override def fpgaModel: FpgaModelDac = {
     fpga
   }
 
@@ -26,22 +17,22 @@ abstract class SramChannelBase[T](val name: String, val dacBoard: DacBoard) exte
   //
   // Blocks
   //
-  protected var currentBlock: String = null
-  def getCurrentBlock(): String = {
-    currentBlock
+  protected var _currentBlock: String = null
+  def currentBlock: String = {
+    _currentBlock
   }
   def setCurrentBlock(block: String): Unit = {
-    currentBlock = block
+    _currentBlock = block
   }
 
   protected val blocks = mutable.Map.empty[String, T]
 
   // Start delay
   override def startDelay: Int = {
-    this.getFpgaModel().getStartDelay()
+    fpgaModel.startDelay
   }
 
   override def setStartDelay(startDelay: Int): Unit = {
-    this.getFpgaModel().setStartDelay(startDelay)
+    fpgaModel.setStartDelay(startDelay)
   }
 }

--- a/QubitServer/src/main/scala/org/labrad/qubits/channels/TriggerChannel.scala
+++ b/QubitServer/src/main/scala/org/labrad/qubits/channels/TriggerChannel.scala
@@ -7,7 +7,7 @@ import org.labrad.qubits.channeldata.TriggerDataTime
 import org.labrad.qubits.enums.DacTriggerId
 import org.labrad.qubits.resources.DacBoard
 
-class TriggerChannel(name: String, board: DacBoard, triggerId: DacTriggerId) extends SramChannelBase[TriggerData](name, board) {
+class TriggerChannel(name: String, board: DacBoard, val triggerId: DacTriggerId) extends SramChannelBase[TriggerData](name, board) {
 
   override def setFpgaModel(fpga: FpgaModel): Unit = {
     fpga match {
@@ -20,22 +20,18 @@ class TriggerChannel(name: String, board: DacBoard, triggerId: DacTriggerId) ext
     }
   }
 
-  def getShift(): Int = {
+  def shift: Int = {
     triggerId.getShift()
   }
 
-  def getTriggerId(): DacTriggerId = {
-    triggerId
-  }
-
   def addData(data: TriggerData): Unit = {
-    val expected = fpga.getBlockLength(currentBlock)
+    val expected = fpga.blockLength(currentBlock)
     data.checkLength(expected)
     blocks.put(currentBlock, data)
   }
 
   def addPulse(start: Int, len: Int): Unit = {
-    val data = getSramData(currentBlock)
+    val data = sramData(currentBlock)
     val newStart = Math.max(0, start)
     val end = Math.min(data.length, newStart + len)
     for (i <- start until end) {
@@ -43,10 +39,10 @@ class TriggerChannel(name: String, board: DacBoard, triggerId: DacTriggerId) ext
     }
   }
 
-  def getSramData(name: String): Array[Boolean] = {
+  def sramData(name: String): Array[Boolean] = {
     val trigger = blocks.getOrElseUpdate(name, {
       // create a dummy data block
-      val length = fpga.getBlockLength(name)
+      val length = fpga.blockLength(name)
       val zeros = Array.ofDim[Boolean](length)
       val d = new TriggerDataTime(zeros)
       d.setChannel(this)

--- a/QubitServer/src/main/scala/org/labrad/qubits/config/AdcBaseConfig.scala
+++ b/QubitServer/src/main/scala/org/labrad/qubits/config/AdcBaseConfig.scala
@@ -7,10 +7,10 @@ abstract class AdcBaseConfig(channelName: String, builProperties: Map[String, Lo
   /**
    * number of clock cycles to delay
    */
-  protected var startDelay: Int = -1
+  protected var _startDelay: Int = -1
 
   def setStartDelay(startDelay: Int): Unit = {
-    this.startDelay = startDelay
+    _startDelay = startDelay
   }
 
   /**
@@ -32,8 +32,8 @@ abstract class AdcBaseConfig(channelName: String, builProperties: Map[String, Lo
    */
   def interpretPhases(Is: Array[Int], Qs: Array[Int], channel: Int): Array[Boolean]
 
-  def getStartDelay(): Int = {
-    startDelay
+  def startDelay: Int = {
+    _startDelay
   }
 
 }

--- a/QubitServer/src/main/scala/org/labrad/qubits/config/AdcDemodConfig.scala
+++ b/QubitServer/src/main/scala/org/labrad/qubits/config/AdcDemodConfig.scala
@@ -77,7 +77,7 @@ class AdcDemodConfig(name: String, buildProperties: Map[String, Long]) extends A
   /**
    * @return array of booleans telling use state of each channel.
    */
-  def getChannelUsage(): Array[Boolean] = {
+  def channelUsage: Array[Boolean] = {
     inUse
   }
 

--- a/QubitServer/src/main/scala/org/labrad/qubits/config/MicrowaveSourceConfig.scala
+++ b/QubitServer/src/main/scala/org/labrad/qubits/config/MicrowaveSourceConfig.scala
@@ -7,5 +7,5 @@ trait MicrowaveSourceConfig {
   def frequency: Double
   def power: Double
 
-  def getSetupPacket(src: MicrowaveSource): SetupPacket
+  def setupPacket(src: MicrowaveSource): SetupPacket
 }

--- a/QubitServer/src/main/scala/org/labrad/qubits/config/MicrowaveSourceOffConfig.scala
+++ b/QubitServer/src/main/scala/org/labrad/qubits/config/MicrowaveSourceOffConfig.scala
@@ -18,7 +18,7 @@ case object MicrowaveSourceOffConfig extends MicrowaveSourceConfig {
     false
   }
 
-  override def getSetupPacket(src: MicrowaveSource): SetupPacket = {
+  override def setupPacket(src: MicrowaveSource): SetupPacket = {
     val data = Seq(
       "Select Device" -> Str(src.name),
       "Output" -> Bool(false)

--- a/QubitServer/src/main/scala/org/labrad/qubits/config/MicrowaveSourceOnConfig.scala
+++ b/QubitServer/src/main/scala/org/labrad/qubits/config/MicrowaveSourceOnConfig.scala
@@ -9,7 +9,7 @@ case class MicrowaveSourceOnConfig(frequency: Double, power: Double) extends Mic
     true
   }
 
-  override def getSetupPacket(src: MicrowaveSource): SetupPacket = {
+  override def setupPacket(src: MicrowaveSource): SetupPacket = {
     val data = Seq(
       "Select Device" -> Str(src.name),
       "Output" -> Bool(true),

--- a/QubitServer/src/main/scala/org/labrad/qubits/config/PreampConfig.scala
+++ b/QubitServer/src/main/scala/org/labrad/qubits/config/PreampConfig.scala
@@ -38,8 +38,8 @@ case class PreampConfig(offset: Long, polarity: Boolean, highPassName: String, l
     sys.error(s"Invalid low-pass filter value '$lowPassName'.  Must be one of ${lowPassFilters.keys.mkString(",")}")
   }
 
-  def getSetupPacket(ch: PreampChannel): SetupPacket = {
-    val chName = ch.getPreampBoard().name
+  def setupPacket(ch: PreampChannel): SetupPacket = {
+    val chName = ch.preampBoard.name
     val linkNameEnd = chName.indexOf("Preamp") - 1
     val linkName = chName.substring(0, linkNameEnd)
     val cardId = (chName.substring(linkNameEnd + "Preamp".length() + 2)).toLong
@@ -48,13 +48,13 @@ case class PreampConfig(offset: Long, polarity: Boolean, highPassName: String, l
       "Connect" -> Str(linkName),
       "Select Card" -> UInt(cardId),
       "Register" -> Cluster(
-        Str(ch.getPreampChannel.toString.toUpperCase),
+        Str(ch.preampChannel.toString.toUpperCase),
         Cluster(UInt(highPass), UInt(lowPass), UInt(if (polarity) 1 else 0), UInt(offset))
       ),
       "Disconnect" -> Data.NONE
     )
 
-    val state = s"${ch.getPreampBoard.name}${ch.getPreampChannel}: offset=$offset polarity=$polarity highPass=$highPass lowPass=$lowPass"
+    val state = s"${ch.preampBoard.name}${ch.preampChannel}: offset=$offset polarity=$polarity highPass=$highPass lowPass=$lowPass"
 
     SetupPacket(state, settings)
   }

--- a/QubitServer/src/main/scala/org/labrad/qubits/controller/FpgaController.scala
+++ b/QubitServer/src/main/scala/org/labrad/qubits/controller/FpgaController.scala
@@ -9,8 +9,8 @@ import org.labrad.qubits.FpgaModelDac
  */
 abstract class FpgaController(protected val fpga: FpgaModelDac) {
 
-  def getSequenceLength_us(): Double
-  def getSequenceLengthPostSRAM_us(): Double
+  def sequenceLength_us: Double
+  def sequenceLengthPostSRAM_us: Double
 
   def hasDualBlockSram(): Boolean
 

--- a/QubitServer/src/main/scala/org/labrad/qubits/controller/JumpTableController.scala
+++ b/QubitServer/src/main/scala/org/labrad/qubits/controller/JumpTableController.scala
@@ -32,11 +32,11 @@ class JumpTableController(fpga: FpgaModelDac) extends FpgaController(fpga) {
     jumpTable.addEntry(name, data)
   }
 
-  override def getSequenceLength_us(): Double = {
+  override def sequenceLength_us: Double = {
     sys.error("TODO: implement get sequence length for JT.")
   }
 
-  override def getSequenceLengthPostSRAM_us(): Double = {
+  override def sequenceLengthPostSRAM_us: Double = {
     sys.error("TODO: implement get sequence length for JT.")
   }
 }

--- a/QubitServer/src/main/scala/org/labrad/qubits/controller/MemoryController.scala
+++ b/QubitServer/src/main/scala/org/labrad/qubits/controller/MemoryController.scala
@@ -16,11 +16,11 @@ class MemoryController(fpga: FpgaModelDac) extends FpgaController(fpga) {
   private var sramCalled = false
   private var sramCalledDualBlock = false
   private var sramDualBlockCmd: CallSramDualBlockCommand = null
-  private var sramDualBlockDelay: Double = -1
+  private var _sramDualBlockDelay: Double = -1
 
   def packets: Seq[(String, Data)] = {
     Seq(
-      "Memory" -> Arr(getMemory())
+      "Memory" -> Arr(memoryBits)
     )
   }
 
@@ -58,7 +58,7 @@ class MemoryController(fpga: FpgaModelDac) extends FpgaController(fpga) {
       val lastCmd = this.memory(memSize - 1)
       lastCmd match {
         case delayCmd: DelayCommand =>
-          delayCmd.setDelay(cycles + delayCmd.getDelay)
+          delayCmd.setDelay(cycles + delayCmd.delay)
 
         case _ =>
           addMemoryCommand(new DelayCommand(cycles))
@@ -70,22 +70,22 @@ class MemoryController(fpga: FpgaModelDac) extends FpgaController(fpga) {
 
 
 
-  override def getSequenceLength_us(): Double = {
-    var t_us = this.fpga.getStartDelay() * FpgaModelDac.START_DELAY_UNIT_NS / 1000.0
+  override def sequenceLength_us: Double = {
+    var t_us = this.fpga.startDelay * FpgaModelDac.START_DELAY_UNIT_NS / 1000.0
     for (memCmd <- this.memory) {
-      t_us += memCmd.getTime_us(fpga)
+      t_us += memCmd.time_us(fpga)
     }
     t_us
   }
-  override def getSequenceLengthPostSRAM_us(): Double = {
-    var t_us = this.fpga.getStartDelay() * FpgaModelDac.START_DELAY_UNIT_NS / 1000.0
+  override def sequenceLengthPostSRAM_us: Double = {
+    var t_us = this.fpga.startDelay * FpgaModelDac.START_DELAY_UNIT_NS / 1000.0
     var SRAMStarted = false
     for (memCmd <- this.memory) {
       if (memCmd.isInstanceOf[CallSramDualBlockCommand] || memCmd.isInstanceOf[CallSramCommand]) {
         SRAMStarted = true
       }
       if (SRAMStarted) {
-        t_us += memCmd.getTime_us(fpga)
+        t_us += memCmd.time_us(fpga)
       }
     }
     t_us
@@ -159,21 +159,21 @@ class MemoryController(fpga: FpgaModelDac) extends FpgaController(fpga) {
   def callSramDualBlock(block1: String, block2: String): Unit = {
     require(!sramCalled, "Cannot call SRAM and dual-block in the same sequence.")
     require(!sramCalledDualBlock, "Only one dual-block SRAM call allowed per sequence.")
-    val cmd = new CallSramDualBlockCommand(block1, block2, sramDualBlockDelay)
+    val cmd = new CallSramDualBlockCommand(block1, block2, _sramDualBlockDelay)
     addMemoryCommand(cmd)
     sramDualBlockCmd = cmd
     sramCalledDualBlock = true
   }
 
   def setSramDualBlockDelay(delay_ns: Double): Unit = {
-    sramDualBlockDelay = delay_ns
+    _sramDualBlockDelay = delay_ns
     if (sramCalledDualBlock) {
       // need to update the already-created dual-block command
       sramDualBlockCmd.setDelay(delay_ns)
     }
   }
 
-  override def hasDualBlockSram(): Boolean = {
+  override def hasDualBlockSram: Boolean = {
     sramCalledDualBlock
   }
 
@@ -181,9 +181,9 @@ class MemoryController(fpga: FpgaModelDac) extends FpgaController(fpga) {
    * Get the delay between blocks in a dual-block SRAM call
    * @return
    */
-  def getSramDualBlockDelay(): Long = {
+  def sramDualBlockDelay: Long = {
     require(sramCalledDualBlock, "Sequence does not have a dual-block SRAM call")
-    sramDualBlockCmd.getDelay().toLong
+    sramDualBlockCmd.delay.toLong
   }
 
 
@@ -195,7 +195,7 @@ class MemoryController(fpga: FpgaModelDac) extends FpgaController(fpga) {
   /**
    * Get the bits of the memory sequence for this board
    */
-  def getMemory(): Array[Long] = {
+  def memoryBits: Array[Long] = {
     // add initial noop and final mem commands
     val mem = NoopCommand +: memory.toArray :+ EndSequenceCommand
 
@@ -203,14 +203,14 @@ class MemoryController(fpga: FpgaModelDac) extends FpgaController(fpga) {
     for (c <- mem) {
       c match {
         case cmd: CallSramCommand =>
-          val block = cmd.getBlockName()
-          if (fpga.getBlockNames().contains(block)) {
-            cmd.setStartAddress(fpga.getBlockStartAddress(block))
-            cmd.setEndAddress(fpga.getBlockEndAddress(block))
+          val block = cmd.blockName
+          if (fpga.blockNames.contains(block)) {
+            cmd.setStartAddress(fpga.blockStartAddress(block))
+            cmd.setEndAddress(fpga.blockEndAddress(block))
           } else {
             // if this block wasn't defined for us, then it will be filled with zeros
             cmd.setStartAddress(0)
-            cmd.setEndAddress(fpga.getExperiment().getShortestSram())
+            cmd.setEndAddress(fpga.experiment.shortestSram)
           }
 
         case _ => // do nothing
@@ -218,22 +218,22 @@ class MemoryController(fpga: FpgaModelDac) extends FpgaController(fpga) {
     }
 
     // get bits for all memory commands
-    val bits = mem.flatMap(_.getBits)
+    val bits = mem.flatMap(_.cmdBits)
 
     // check that the total memory sequence is not too long
-    if (bits.length > fpga.getDacBoard.buildProperties("SRAM_WRITE_PKT_LEN")) {
+    if (bits.length > fpga.dacBoard.buildProperties("SRAM_WRITE_PKT_LEN")) {
       sys.error("Memory sequence exceeds maximum length")
     }
     bits
   }
 
-  def getDualBlockName1(): String = {
+  def dualBlockName1: String = {
     require(sramCalledDualBlock, "Sequence does not have a dual-block SRAM call")
-    sramDualBlockCmd.getBlockName1()
+    sramDualBlockCmd.block1
   }
 
-  def getDualBlockName2(): String = {
+  def dualBlockName2: String = {
     require(sramCalledDualBlock, "Sequence does not have a dual-block SRAM call")
-    sramDualBlockCmd.getBlockName2()
+    sramDualBlockCmd.block2
   }
 }

--- a/QubitServer/src/main/scala/org/labrad/qubits/mem/CallSramCommand.scala
+++ b/QubitServer/src/main/scala/org/labrad/qubits/mem/CallSramCommand.scala
@@ -2,13 +2,9 @@ package org.labrad.qubits.mem
 
 import org.labrad.qubits.FpgaModelDac
 
-class CallSramCommand(blockName: String) extends MemoryCommand {
+class CallSramCommand(val blockName: String) extends MemoryCommand {
   private var startAddr: Int = 0
   private var endAddr: Int = 0
-
-  def getBlockName(): String = {
-    blockName
-  }
 
   def setStartAddress(startAddr: Int): Unit = {
     this.startAddr = startAddr
@@ -18,13 +14,13 @@ class CallSramCommand(blockName: String) extends MemoryCommand {
     this.endAddr = endAddr
   }
 
-  def getBits(): Array[Long] = {
+  def cmdBits: Array[Long] = {
     Array[Long](0x800000 + (startAddr & 0x0FFFFF),
                 0xA00000 + (endAddr & 0x0FFFFF),
                 0xC00000)
   }
 
-  def getTime_us(dac: FpgaModelDac): Double = {
+  def time_us(dac: FpgaModelDac): Double = {
     // Call Sram memory command includes 3 memory commands plus the SRAM sequence
     dac.samplesToMicroseconds(endAddr - startAddr) + FpgaModelDac.clocksToMicroseconds(3)
   }

--- a/QubitServer/src/main/scala/org/labrad/qubits/mem/CallSramDualBlockCommand.scala
+++ b/QubitServer/src/main/scala/org/labrad/qubits/mem/CallSramDualBlockCommand.scala
@@ -2,35 +2,27 @@ package org.labrad.qubits.mem
 
 import org.labrad.qubits.FpgaModelDac
 
-class CallSramDualBlockCommand(block1: String, block2: String, var delay: Double = -1) extends MemoryCommand {
+class CallSramDualBlockCommand(val block1: String, val block2: String, private var _delay: Double = -1) extends MemoryCommand {
 
-  def getBlockName1(): String = {
-    block1
-  }
-
-  def getBlockName2(): String = {
-    block2
-  }
-
-  def getDelay(): Double = {
+  def delay: Double = {
     require(delay > 0, "Dual-block SRAM delay not set!")
     delay
   }
 
   def setDelay(delay: Double): Unit = {
-    this.delay = delay
+    _delay = delay
   }
 
-  def getBits(): Array[Long] = {
+  def cmdBits: Array[Long] = {
     // the GHz DACs server handles layout of SRAM for dual block
     Array[Long](0x800000, 0xA00000, 0xC00000)
   }
 
-  def getTime_us(dac: FpgaModelDac): Double = {
+  def time_us(dac: FpgaModelDac): Double = {
     // Call Sram memory command includes 3 memory commands plus the SRAM sequence
     require(delay > 0, "Dual-block SRAM delay not set!")
-    val b1len = dac.getBlockLength(block1)
-    val b2len = dac.getBlockLength(block2)
+    val b1len = dac.blockLength(block1)
+    val b2len = dac.blockLength(block2)
     dac.samplesToMicroseconds(b1len + b2len) + FpgaModelDac.clocksToMicroseconds(3) + this.delay / 1000.0
   }
 }

--- a/QubitServer/src/main/scala/org/labrad/qubits/mem/DelayCommand.scala
+++ b/QubitServer/src/main/scala/org/labrad/qubits/mem/DelayCommand.scala
@@ -8,15 +8,15 @@ class DelayCommand(var cycles: Int) extends MemoryCommand {
     this.cycles = cycles
   }
 
-  def getDelay(): Int = {
+  def delay: Int = {
     this.cycles
   }
 
-  def getTime_us(dac: FpgaModelDac): Double = {
+  def time_us(dac: FpgaModelDac): Double = {
     FpgaModelDac.clocksToMicroseconds(this.cycles)
   }
 
-  def getBits(): Array[Long] = {
+  def cmdBits: Array[Long] = {
     var left = cycles
     val arr = Array.newBuilder[Long]
     while (left > 0x0FFFFF) {

--- a/QubitServer/src/main/scala/org/labrad/qubits/mem/EndSequenceCommand.scala
+++ b/QubitServer/src/main/scala/org/labrad/qubits/mem/EndSequenceCommand.scala
@@ -3,11 +3,11 @@ package org.labrad.qubits.mem
 import org.labrad.qubits.FpgaModelDac
 
 object EndSequenceCommand extends MemoryCommand {
-  def getBits(): Array[Long] = {
+  def cmdBits: Array[Long] = {
     Array(0xF00000)
   }
 
-  def getTime_us(dac: FpgaModelDac): Double = {
+  def time_us(dac: FpgaModelDac): Double = {
     FpgaModelDac.clocksToMicroseconds(1)
   }
 }

--- a/QubitServer/src/main/scala/org/labrad/qubits/mem/FastBiasCommands.scala
+++ b/QubitServer/src/main/scala/org/labrad/qubits/mem/FastBiasCommands.scala
@@ -5,8 +5,8 @@ import org.labrad.qubits.enums.BiasCommandType
 import org.labrad.qubits.enums.BiasCommandType._
 
 object FastBiasCommands {
-  def get(cmdType: BiasCommandType, fb: FastBiasChannel, v: Double): SendFiberCommand = {
-    val gain = fb.getFastBias().getGain(fb.getDcFiberId())
+  def apply(cmdType: BiasCommandType, fb: FastBiasChannel, v: Double): SendFiberCommand = {
+    val gain = fb.fastBias.gain(fb.dcRackFiberId)
     val vSend = v / gain
     cmdType match {
       case DAC0 => setDac0(fb, vSend)
@@ -41,6 +41,6 @@ object FastBiasCommands {
   }
 
   private def makeCommand(fb: FastBiasChannel, bits: Int): SendFiberCommand = {
-    SendFiberCommand(fb.getFiberId(), bits)
+    SendFiberCommand(fb.dacFiberId, bits)
   }
 }

--- a/QubitServer/src/main/scala/org/labrad/qubits/mem/MemoryCommand.scala
+++ b/QubitServer/src/main/scala/org/labrad/qubits/mem/MemoryCommand.scala
@@ -3,6 +3,6 @@ package org.labrad.qubits.mem
 import org.labrad.qubits.FpgaModelDac
 
 trait MemoryCommand {
-  def getBits(): Array[Long]
-  def getTime_us(dac: FpgaModelDac): Double
+  def cmdBits: Array[Long]
+  def time_us(dac: FpgaModelDac): Double
 }

--- a/QubitServer/src/main/scala/org/labrad/qubits/mem/NoopCommand.scala
+++ b/QubitServer/src/main/scala/org/labrad/qubits/mem/NoopCommand.scala
@@ -3,11 +3,11 @@ package org.labrad.qubits.mem
 import org.labrad.qubits.FpgaModelDac
 
 object NoopCommand extends MemoryCommand {
-  def getBits(): Array[Long] = {
+  def cmdBits: Array[Long] = {
     Array[Long](0x000000)
   }
 
-  def getTime_us(dac: FpgaModelDac): Double = {
+  def time_us(dac: FpgaModelDac): Double = {
     FpgaModelDac.clocksToMicroseconds(1)
   }
 }

--- a/QubitServer/src/main/scala/org/labrad/qubits/mem/SendFiberCommand.scala
+++ b/QubitServer/src/main/scala/org/labrad/qubits/mem/SendFiberCommand.scala
@@ -5,7 +5,7 @@ import org.labrad.qubits.enums.DacFiberId
 
 case class SendFiberCommand(channel: DacFiberId, bits: Int) extends MemoryCommand {
 
-  def getBits(): Array[Long] = {
+  def cmdBits: Array[Long] = {
     val send = channel match {
       case DacFiberId.FOUT_0 => 0x100000
       case DacFiberId.FOUT_1 => 0x200000
@@ -14,7 +14,7 @@ case class SendFiberCommand(channel: DacFiberId, bits: Int) extends MemoryComman
     Array[Long](send + (bits & 0x0FFFFF))
   }
 
-  def getTime_us(dac: FpgaModelDac): Double = {
+  def time_us(dac: FpgaModelDac): Double = {
     FpgaModelDac.clocksToMicroseconds(1)
   }
 }

--- a/QubitServer/src/main/scala/org/labrad/qubits/mem/StartTimerCommand.scala
+++ b/QubitServer/src/main/scala/org/labrad/qubits/mem/StartTimerCommand.scala
@@ -3,11 +3,11 @@ package org.labrad.qubits.mem
 import org.labrad.qubits.FpgaModelDac
 
 object StartTimerCommand extends MemoryCommand {
-  def getBits(): Array[Long] = {
+  def cmdBits: Array[Long] = {
     Array[Long](0x400000)
   }
 
-  def getTime_us(dac: FpgaModelDac): Double = {
+  def time_us(dac: FpgaModelDac): Double = {
     FpgaModelDac.clocksToMicroseconds(1)
   }
 }

--- a/QubitServer/src/main/scala/org/labrad/qubits/mem/StopTimerCommand.scala
+++ b/QubitServer/src/main/scala/org/labrad/qubits/mem/StopTimerCommand.scala
@@ -3,11 +3,11 @@ package org.labrad.qubits.mem
 import org.labrad.qubits.FpgaModelDac
 
 object StopTimerCommand extends MemoryCommand {
-  def getBits(): Array[Long] = {
+  def cmdBits: Array[Long] = {
     Array[Long](0x400001)
   }
 
-  def getTime_us(dac: FpgaModelDac): Double = {
+  def time_us(dac: FpgaModelDac): Double = {
     FpgaModelDac.clocksToMicroseconds(1)
   }
 }

--- a/QubitServer/src/main/scala/org/labrad/qubits/resources/DacBoard.scala
+++ b/QubitServer/src/main/scala/org/labrad/qubits/resources/DacBoard.scala
@@ -11,10 +11,6 @@ abstract class DacBoard(val name: String, val buildNumber: String, val buildProp
 
   val buildType = "dacBuild" // either 'adcBuild' or 'dacBuild'
 
-  def getBuildType(): String = {
-    buildType
-  }
-
   def setFiber(fiber: DacFiberId, board: BiasBoard, channel: DcRackFiberId): Unit = {
     fibers.put(fiber, board)
     fiberChannels.put(fiber, channel)

--- a/QubitServer/src/main/scala/org/labrad/qubits/resources/FastBias.scala
+++ b/QubitServer/src/main/scala/org/labrad/qubits/resources/FastBias.scala
@@ -24,15 +24,15 @@ class FastBias(val name: String) extends BiasBoard {
     dacFibers.put(channel, fiber)
   }
 
-  def getDacBoard(channel: DcRackFiberId): DacBoard = {
+  def dacBoard(channel: DcRackFiberId): DacBoard = {
     dacBoards.getOrElse(channel, sys.error(s"No DAC board wired to channel $channel on board $name"))
   }
 
-  def getFiber(channel: DcRackFiberId): DacFiberId = {
+  def dacFiber(channel: DcRackFiberId): DacFiberId = {
     dacFibers.getOrElse(channel, sys.error(s"No DAC board wired to channel $channel on board $name"))
   }
 
-  def getGain(channel: DcRackFiberId): Double = {
+  def gain(channel: DcRackFiberId): Double = {
     gains.getOrElse(channel, 1.0)
   }
 

--- a/QubitServer/src/main/scala/org/labrad/qubits/resources/MicrowaveBoard.scala
+++ b/QubitServer/src/main/scala/org/labrad/qubits/resources/MicrowaveBoard.scala
@@ -13,7 +13,7 @@ class MicrowaveBoard(name: String, buildNumber: String, buildProperties: Map[Str
     this.uwaveSrc = uwaves
   }
 
-  def getMicrowaveSource(): MicrowaveSource = {
+  def microwaveSource: MicrowaveSource = {
     uwaveSrc
   }
 }

--- a/QubitServer/src/main/scala/org/labrad/qubits/resources/MicrowaveSource.scala
+++ b/QubitServer/src/main/scala/org/labrad/qubits/resources/MicrowaveSource.scala
@@ -15,7 +15,7 @@ class MicrowaveSource(val name: String) extends Resource {
     boards += board
   }
 
-  def getMicrowaveBoards(): Set[MicrowaveBoard] = {
+  def microwaveBoards: Set[MicrowaveBoard] = {
     boards.toSet
   }
 }

--- a/QubitServer/src/main/scala/org/labrad/qubits/resources/PreampBoard.scala
+++ b/QubitServer/src/main/scala/org/labrad/qubits/resources/PreampBoard.scala
@@ -20,11 +20,11 @@ class PreampBoard(val name: String) extends BiasBoard {
     dacFibers.put(channel, fiber)
   }
 
-  def getDacBoard(channel: DcRackFiberId): DacBoard = {
+  def dacBoard(channel: DcRackFiberId): DacBoard = {
     dacBoards.getOrElse(channel, sys.error(s"No DAC board wired to channel $channel on board $name"))
   }
 
-  def getFiber(channel: DcRackFiberId): DacFiberId = {
+  def dacFiber(channel: DcRackFiberId): DacFiberId = {
     dacFibers.getOrElse(channel, sys.error(s"No DAC board wired to channel $channel on board $name"))
   }
 }


### PR DESCRIPTION
Includes a bunch of small renaming changes. These are changes of the "if it compiles, it works" sort. Just trying to clean up the naming and remove getters where possible.