### PR TITLE
datavault: Fix labrad_urlencode to work with new FlatData type

### DIFF
--- a/datavault/backend.py
+++ b/datavault/backend.py
@@ -40,8 +40,14 @@ def time_from_str(s):
     return datetime.datetime.strptime(s, TIME_FORMAT)
 
 def labrad_urlencode(data):
-    data_bytes, t = T.flatten(data)
-    all_bytes, _ = T.flatten((str(t), data_bytes), 'ss')
+    if hasattr(T, 'FlatData'):
+        # pylabrad 0.95+
+        flat_data = T.flatten(data)
+        flat_cluster = T.flatten((str(flat_data.tag), flat_data.bytes), 'sy')
+        all_bytes = flat_cluster.bytes
+    else:
+        data_bytes, t = T.flatten(data)
+        all_bytes, _ = T.flatten((str(t), data_bytes), 'ss')
     data_url = DATA_URL_PREFIX + base64.urlsafe_b64encode(all_bytes)
     return data_url
 

--- a/tests/test_datavault.py
+++ b/tests/test_datavault.py
@@ -239,10 +239,9 @@ def test_parameters(dv):
         name = 'param{}'.format(i)
         dv.add_parameter(name, a)
         b = dv.get_parameter(name)
-        sa, ta = T.flatten(a)
-        sb, tb = T.flatten(b)
-        assert ta == tb
-        assert sa == sb
+        flat_a = T.flatten(a)
+        flat_b = T.flatten(b)
+        assert flat_a == flat_b
 
 
 # Test asynchronous notification signals.


### PR DESCRIPTION
The FlatData type is a namedtuple that replaces the plain tuple returned by older versions of pylabrad when flattening data. We modify the labrad_urlencode method to use names of the FlatData items if possible, rather than explicitly unpacking the tuple. This lets us maintain compatibility with changes in 0.95.2 which added a third endianness member to the FlatData tuple.
