### PR TITLE
Allow specifying known devices in the registry. 

### DIFF
--- a/gpib_server.py
+++ b/gpib_server.py
@@ -126,7 +126,7 @@ class GPIBBusServer(LabradServer):
         try:
             rm = visa.ResourceManager()
             registry_devices = yield self.getRegistryDevices()
-            addresses = [str(x) for x in rm.list_resources()]
+            addresses = [str(x) for x in rm.list_resources()] + registry_devices
             additions = set(addresses) - set(self.devices.keys())
             deletions = set(self.devices.keys()) - set(addresses)
             for addr in additions:


### PR DESCRIPTION
Some instruments don't show up in the visa resource manager.  So we allow you to specify a list of addresses in the registry. Completely untested.